### PR TITLE
Handle case where only options are passed.

### DIFF
--- a/jc/cli.py
+++ b/jc/cli.py
@@ -209,6 +209,10 @@ def magic():
             else:
                 break
 
+    if len(args_given) == 0:
+        # This was a call to jc with just options and no commands.
+        return
+
     # find the command and parser
     command = ' '.join(args_given[0:2])
     for parser in parser_info:


### PR DESCRIPTION
Arguments can appear like so: `-*`, `--*`, or `*`. Since we pop all args that match `-*` and return if `--*` exists, all that is left is keywords that match `*` - if these are not present, then the only thing that was in args_given was options, and so we should return.