### PR TITLE
Simplify process() in history.py, avoid list allocation in parse()

### DIFF
--- a/jc/parsers/history.py
+++ b/jc/parsers/history.py
@@ -79,21 +79,11 @@ def process(proc_data):
     # rebuild output for added semantic information
     processed = []
     for k, v in proc_data.items():
-        proc_line = {}
-        proc_line['line'] = k
-        proc_line['command'] = v
+        proc_line = {
+            'line': int(k) if k.isdigit() else None,
+            'command': v,
+        }
         processed.append(proc_line)
-
-    for entry in processed:
-        int_list = ['line']
-        for key in int_list:
-            if key in entry:
-                try:
-                    key_int = int(entry[key])
-                    entry[key] = key_int
-                except (ValueError):
-                    entry[key] = None
-
     return processed
 
 
@@ -120,17 +110,14 @@ def parse(data, raw=False, quiet=False):
     # split lines and clear out any non-ascii chars
     linedata = data.encode('ascii', errors='ignore').decode().splitlines()
 
-    # Clear any blank lines
-    cleandata = list(filter(None, linedata))
-
-    if cleandata:
-        for entry in cleandata:
-            try:
-                parsed_line = entry.split(maxsplit=1)
-                raw_output[parsed_line[0]] = parsed_line[1]
-            except IndexError:
-                # need to catch indexerror in case there is weird input from prior commands
-                pass
+    # Skip any blank lines
+    for entry in filter(None, linedata):
+        try:
+            parsed_line = entry.split(maxsplit=1)
+            raw_output[parsed_line[0]] = parsed_line[1]
+        except IndexError:
+            # need to catch indexerror in case there is weird input from prior commands
+            pass
 
     if raw:
         return raw_output


### PR DESCRIPTION
Instead of doing two passes over the data in process(), it is possible to do one pass, which makes the code a lot simpler - using .isdigit() also helps avoid additional exception checks.

 In parse(), we don't use cleandata anywhere else, so we don't need to allocate a list, since filter() is iterable. This helps avoid a list allocation, and if all strings are empty, we will not enter the loop for filter - for instance:

```
a = ["", '', "", "hello"]
for word in filter(None, a):
    print(word)
>>> hello
```

You can iterate over the filter directly for almost every parser, which would help simplify and speed the code up since you would avoid a list allocation each time.