### PR TITLE
Load custom parsers from <user_data_dir>/jc/jcparsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,13 @@ Tested on:
 - NixOS
 - FreeBSD12
 
+
+## Custom Parsers
+Custom local plugins may be placed in a "jc/jcparsers" folder in your local "App data directory" (For example, "/home/*myname*/.local/jc/jcparsers" on Linux, "/Users/*myname*/Library/Application Support/jc/jcparsers" on Mac OS X, or "C:\Users\*myname*\AppData\Local\jc\jc\jcparsers" on Windows.
+
+Use the [`jc/parsers/foo.py`](https://github.com/kellyjonbrazil/jc/blob/master/jc/parsers/foo.py) parser as a template and simply place a `.py` file in the `jcparsers` subfolder. Local plugin file names must be valid python module names, therefore must consist entirely of alphanumerics and start with a letter. Local plugins may override default plugins.
+
+
 ## Contributions
 Feel free to add/improve code or parsers! You can use the [`jc/parsers/foo.py`](https://github.com/kellyjonbrazil/jc/blob/master/jc/parsers/foo.py) parser as a template and submit your parser with a pull request.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+appdirs>=1.4.0
 ruamel.yaml>=0.15.0
 xmltodict>=0.12.0
 Pygments>=2.4.2

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setuptools.setup(
     author_email='kellyjonbrazil@gmail.com',
     description='Converts the output of popular command-line tools and file-types to JSON.',
     install_requires=[
+        'appdirs>=1.4.0',
         'ruamel.yaml>=0.15.0',
         'xmltodict>=0.12.0',
         'Pygments>=2.4.2'


### PR DESCRIPTION
Hello, I'd like to propose a feature for custom (local) parsers. Benefits:

* Lower the barrier for entry to write new parsers
* Allow override of builtin parsers for strange systems or command-line arguments
* Allow use of jc with uncommon or specialized apps (for which upstream submission would not be appropriate)

This PR includes such a feature and will include parsers present in `.py`
files placed into the `jc/jcparsers` folder of a user's app-data directory.
Determining an appropriate app-data directory for the current OS did
require a new dependency on the "appdirs" package.

I have tested the changes on Linux. I don't have a Windows or Mac available
to test or verify the path locations I documented, but these paths seem to
be correct judging from the appdirs documentation. Aside from possibly
mis-documenting the correct extension folders, I do not believe there are
any OS-specific dangers.
