### PR TITLE
iw_scan: Improve detection of lines starting with spaces

### DIFF
--- a/jc/parsers/iw_scan.py
+++ b/jc/parsers/iw_scan.py
@@ -109,6 +109,7 @@ Examples:
       ...
     ]
 """
+import re
 import jc.utils
 
 
@@ -310,7 +311,7 @@ def parse(data, raw=False, quiet=False):
 
                 continue
 
-            if line.startswith('    '):
+            if re.match(r"^\s+.+", line):
                 # ignore problematic lines
                 if 'Maximum RX AMPDU length' in line:
                     continue


### PR DESCRIPTION
Ref https://github.com/kellyjonbrazil/jc/issues/94#issuecomment-755162509

This improves the detections of lines that start with space chars in the iw_scan parser.

Without this one only gets the `mac_address` and `interface` fields on Arch Linux and Termux.