### PR TITLE
Dev v1.14.4

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,10 @@
 jc changelog
 
+20210305 v1.14.4
+- Packaging fix only for binaries and RPMs hosted on https://github.com/kellyjonbrazil/jc-packaging.
+  Packages from PyPi and OS repositories are not affected. This fixes an issue that kept the YAML
+  parser from initializing.
+
 20210210 v1.14.3
 - Add hciconfig parser tested on linux
 - Update dig parser to simplify answer data logic

--- a/jc/cli.py
+++ b/jc/cli.py
@@ -21,7 +21,7 @@ import jc.appdirs as appdirs
 
 
 class info():
-    version = '1.14.3'
+    version = '1.14.4'
     description = 'JSON CLI output utility'
     author = 'Kelly Brazil'
     author_email = 'kellyjonbrazil@gmail.com'

--- a/jc/parsers/yaml.py
+++ b/jc/parsers/yaml.py
@@ -135,7 +135,7 @@ def parse(data, raw=False, quiet=False):
     if jc.utils.has_data(data):
 
         # monkey patch to disable plugins since we don't use them and in
-        # ruamel.yaml versions prior to 0.17.0 the use of __name__ in the
+        # ruamel.yaml versions prior to 0.17.0 the use of __file__ in the
         # plugin code is incompatible with the pyoxidizer packager
         YAML.official_plug_ins = lambda a: []
 

--- a/jc/parsers/yaml.py
+++ b/jc/parsers/yaml.py
@@ -76,7 +76,7 @@ from ruamel.yaml import YAML
 
 
 class info():
-    version = '1.1'
+    version = '1.2'
     description = 'YAML file parser'
     author = 'Kelly Brazil'
     author_email = 'kellyjonbrazil@gmail.com'
@@ -133,6 +133,11 @@ def parse(data, raw=False, quiet=False):
     raw_output = []
 
     if jc.utils.has_data(data):
+
+        # monkey patch to disable plugins since we don't use them and in
+        # ruamel.yaml versions prior to 0.17.0 the use of __name__ in the
+        # plugin code is incompatible with the pyoxidizer packager
+        YAML.official_plug_ins = lambda a: []
 
         yaml = YAML(typ='safe')
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as f:
 
 setuptools.setup(
     name='jc',
-    version='1.14.3',
+    version='1.14.4',
     author='Kelly Brazil',
     author_email='kellyjonbrazil@gmail.com',
     description='Converts the output of popular command-line tools and file-types to JSON.',


### PR DESCRIPTION
- Packaging fix only for binaries and RPMs hosted on https://github.com/kellyjonbrazil/jc-packaging. Packages from PyPi and OS repositories are not affected. This fixes an issue that kept the YAML parser from initializing.