### PR TITLE
Dev 1.17.4

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 jc changelog
 
 20211207 v1.17.4
-- Add support for the NO_COLOR environment variable to force mono
+- Add support for the NO_COLOR environment variable to set mono (http://no-color.org/)
 - Add -C option to force color output even when using pipes (overrides -m and NO_COLOR)
 
 20211202 v1.17.3

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 jc changelog
 
+20211207 v1.17.4
+- Add support for the NO_COLOR environment variable to force mono
+
 20211202 v1.17.3
 - Update parsers to exit with error if non-string input is detected (raise TypeError)
 - Update streaming parsers to exit with error if non-iterable input is detected (raise TypeError)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@ jc changelog
 
 20211207 v1.17.4
 - Add support for the NO_COLOR environment variable to force mono
+- Add -C option to force color output even when using pipes (overrides -m and NO_COLOR)
 
 20211202 v1.17.3
 - Update parsers to exit with error if non-string input is detected (raise TypeError)

--- a/README.md
+++ b/README.md
@@ -230,6 +230,9 @@ or
 JC_COLORS=default,default,default,default
 ```
 
+### Disable Colors via Environment Variable
+You can set the [`NO_COLOR`](http://no-color.org/) environment variable to any value to disable color output in `jc`. Note that using the `-C` option to force color output will override both the `NO_COLOR` environment variable and the `-m` option.
+
 ### Streaming Parsers
 Most parsers load all of the data from STDIN, parse it, then output the entire JSON document serially. There are some streaming parsers (e.g. `ls-s` and `ping-s`) that immediately start processing and outputing the data line-by-line as [JSON Lines](https://jsonlines.org/) (aka [NDJSON](http://ndjson.org/)) while it is being received from STDIN. This can significantly reduce the amount of memory required to parse large amounts of command output (e.g. `ls -lR /`) and can sometimes process the data more quickly. Streaming parsers have slightly different behavior than standard parsers as outlined below.
 

--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ The JSON output can be compact (default) or pretty formatted with the `-p` optio
 
 ### Options
 - `-a` about `jc`. Prints information about `jc` and the parsers (in JSON, of course!)
+- `-C` force color output even when using pipes (overrides `-m` and the `NO_COLOR` env variable)
 - `-d` debug mode. Prints trace messages if parsing issues are encountered (use `-dd` for verbose debugging)
 - `-h` help. Use `jc -h --parser_name` for parser documentation
 - `-m` monochrome JSON output

--- a/jc/__init__.py
+++ b/jc/__init__.py
@@ -73,4 +73,4 @@ Module Example:
 """
 
 name = 'jc'
-__version__ = '1.17.3'
+__version__ = '1.17.4'

--- a/jc/cli.py
+++ b/jc/cli.py
@@ -526,7 +526,7 @@ def main():
     about = 'a' in options
     debug = 'd' in options
     verbose_debug = options.count('d') > 1
-    mono = 'm' in options
+    mono = bool('m' in options or os.getenv('NO_COLOR'))
     help_me = 'h' in options
     pretty = 'p' in options
     quiet = 'q' in options

--- a/jc/cli.py
+++ b/jc/cli.py
@@ -526,7 +526,7 @@ def main():
     about = 'a' in options
     debug = 'd' in options
     verbose_debug = options.count('d') > 1
-    mono = bool('m' in options or os.getenv('NO_COLOR'))
+    mono = 'm' in options or bool(os.getenv('NO_COLOR'))
     help_me = 'h' in options
     pretty = 'p' in options
     quiet = 'q' in options

--- a/man/jc.1
+++ b/man/jc.1
@@ -1,4 +1,4 @@
-.TH jc 1 2021-12-02 1.17.3 "JSON CLI output utility"
+.TH jc 1 2021-12-08 1.17.3 "JSON CLI output utility"
 .SH NAME
 jc \- JSONifies the output of many CLI tools and file-types
 .SH SYNOPSIS
@@ -438,6 +438,10 @@ Options:
 .B
 \fB-a\fP
 about jc (JSON output)
+.TP
+.B
+\fB-C\fP
+force color output even when using pipes (overrides `-m` and the `NO_COLOR` env variable)
 .TP
 .B
 \fB-d\fP

--- a/man/jc.1
+++ b/man/jc.1
@@ -1,4 +1,4 @@
-.TH jc 1 2021-12-08 1.17.3 "JSON CLI output utility"
+.TH jc 1 2021-12-08 1.17.4 "JSON CLI output utility"
 .SH NAME
 jc \- JSONifies the output of many CLI tools and file-types
 .SH SYNOPSIS
@@ -441,7 +441,7 @@ about jc (JSON output)
 .TP
 .B
 \fB-C\fP
-force color output even when using pipes (overrides `-m` and the `NO_COLOR` env variable)
+force color output even when using pipes (overrides \fB-m\fP and the \fBNO_COLOR\fP env variable)
 .TP
 .B
 \fB-d\fP
@@ -478,7 +478,7 @@ version information
 .SH EXIT CODES
 Any fatal errors within jc will generate an exit code of \fB100\fP, otherwise the exit code will be \fB0\fP. When using the "Magic" syntax (e.g. \fBjc ifconfig eth0\fP), jc will store the exit code of the program being parsed and add it to the  jc exit code. This way it is easier to determine if an error was from the parsed program or jc.
 
-Consider the following examples using `ifconfig`:
+Consider the following examples using \fBifconfig\fP:
 
 .RS
 ifconfig exit code = \fB0\fP, jc exit code = \fB0\fP, combined exit code = \fB0\fP (no errors)
@@ -512,7 +512,7 @@ JC_COLORS=default,default,default,default
 
 \fBDisable Color Output\fP
 
-You can set the `NO_COLOR` environment variable to any value to disable color output in \fBjc\fP. Note that using the \fB-C\fP option to force color output will override both the \fBNO_COLOR\fP environment variable and the \fB-m\fP option.
+You can set the \fBNO_COLOR\fB environment variable to any value to disable color output in \fBjc\fP. Note that using the \fB-C\fP option to force color output will override both the \fBNO_COLOR\fP environment variable and the \fB-m\fP option.
 
 .SH STREAMING PARSERS
 Most parsers load all of the data from \fBSTDIN\fP, parse it, then output the entire JSON document serially. There are some streaming parsers (e.g. \fBls-s\fP and \fBping-s\fP) that immediately start processing and outputing the data line-by-line as JSON Lines (aka NDJSON) while it is being received from \fBSTDIN\fP. This can significantly reduce the amount of memory required to parse large amounts of command output (e.g. \fBls -lR /\fP) and can sometimes process the data more quickly. Streaming parsers have slightly different behavior than standard parsers as outlined below.

--- a/man/jc.1
+++ b/man/jc.1
@@ -491,6 +491,9 @@ ifconfig exit code = \fB1\fP, jc exit code = \fB100\fP, combined exit code = \fB
 .RE
 
 .SH ENVIRONMENT
+
+\fBCustom Colors\fP
+
 You can specify custom colors via the \fBJC_COLORS\fP environment variable. The \fBJC_COLORS\fP environment variable takes four comma separated string values in the following format:
 
 JC_COLORS=<keyname_color>,<keyword_color>,<number_color>,<string_color>
@@ -507,6 +510,9 @@ or
 JC_COLORS=default,default,default,default
 .RE
 
+\fBDisable Color Output\fP
+
+You can set the `NO_COLOR` environment variable to any value to disable color output in \fBjc\fP. Note that using the \fB-C\fP option to force color output will override both the \fBNO_COLOR\fP environment variable and the \fB-m\fP option.
 
 .SH STREAMING PARSERS
 Most parsers load all of the data from \fBSTDIN\fP, parse it, then output the entire JSON document serially. There are some streaming parsers (e.g. \fBls-s\fP and \fBping-s\fP) that immediately start processing and outputing the data line-by-line as JSON Lines (aka NDJSON) while it is being received from \fBSTDIN\fP. This can significantly reduce the amount of memory required to parse large amounts of command output (e.g. \fBls -lR /\fP) and can sometimes process the data more quickly. Streaming parsers have slightly different behavior than standard parsers as outlined below.

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as f:
 
 setuptools.setup(
     name='jc',
-    version='1.17.3',
+    version='1.17.4',
     author='Kelly Brazil',
     author_email='kellyjonbrazil@gmail.com',
     description='Converts the output of popular command-line tools and file-types to JSON.',

--- a/templates/manpage_template
+++ b/templates/manpage_template
@@ -86,6 +86,9 @@ ifconfig exit code = \fB1\fP, jc exit code = \fB100\fP, combined exit code = \fB
 .RE
 
 .SH ENVIRONMENT
+
+\fBCustom Colors\fP
+
 You can specify custom colors via the \fBJC_COLORS\fP environment variable. The \fBJC_COLORS\fP environment variable takes four comma separated string values in the following format:
 
 JC_COLORS=<keyname_color>,<keyword_color>,<number_color>,<string_color>
@@ -102,6 +105,9 @@ or
 JC_COLORS=default,default,default,default
 .RE
 
+\fBDisable Color Output\fP
+
+You can set the `NO_COLOR` environment variable to any value to disable color output in \fBjc\fP. Note that using the \fB-C\fP option to force color output will override both the \fBNO_COLOR\fP environment variable and the \fB-m\fP option.
 
 .SH STREAMING PARSERS
 Most parsers load all of the data from \fBSTDIN\fP, parse it, then output the entire JSON document serially. There are some streaming parsers (e.g. \fBls-s\fP and \fBping-s\fP) that immediately start processing and outputing the data line-by-line as JSON Lines (aka NDJSON) while it is being received from \fBSTDIN\fP. This can significantly reduce the amount of memory required to parse large amounts of command output (e.g. \fBls -lR /\fP) and can sometimes process the data more quickly. Streaming parsers have slightly different behavior than standard parsers as outlined below.

--- a/templates/manpage_template
+++ b/templates/manpage_template
@@ -35,6 +35,10 @@ Options:
 about jc (JSON output)
 .TP
 .B
+\fB-C\fP
+force color output even when using pipes (overrides `-m` and the `NO_COLOR` env variable)
+.TP
+.B
 \fB-d\fP
 debug - show traceback (use \fB-dd\fP for verbose traceback)
 .TP

--- a/templates/manpage_template
+++ b/templates/manpage_template
@@ -36,7 +36,7 @@ about jc (JSON output)
 .TP
 .B
 \fB-C\fP
-force color output even when using pipes (overrides `-m` and the `NO_COLOR` env variable)
+force color output even when using pipes (overrides \fB-m\fP and the \fBNO_COLOR\fP env variable)
 .TP
 .B
 \fB-d\fP
@@ -73,7 +73,7 @@ version information
 .SH EXIT CODES
 Any fatal errors within jc will generate an exit code of \fB100\fP, otherwise the exit code will be \fB0\fP. When using the "Magic" syntax (e.g. \fBjc ifconfig eth0\fP), jc will store the exit code of the program being parsed and add it to the  jc exit code. This way it is easier to determine if an error was from the parsed program or jc.
 
-Consider the following examples using `ifconfig`:
+Consider the following examples using \fBifconfig\fP:
 
 .RS
 ifconfig exit code = \fB0\fP, jc exit code = \fB0\fP, combined exit code = \fB0\fP (no errors)
@@ -107,7 +107,7 @@ JC_COLORS=default,default,default,default
 
 \fBDisable Color Output\fP
 
-You can set the `NO_COLOR` environment variable to any value to disable color output in \fBjc\fP. Note that using the \fB-C\fP option to force color output will override both the \fBNO_COLOR\fP environment variable and the \fB-m\fP option.
+You can set the \fBNO_COLOR\fB environment variable to any value to disable color output in \fBjc\fP. Note that using the \fB-C\fP option to force color output will override both the \fBNO_COLOR\fP environment variable and the \fB-m\fP option.
 
 .SH STREAMING PARSERS
 Most parsers load all of the data from \fBSTDIN\fP, parse it, then output the entire JSON document serially. There are some streaming parsers (e.g. \fBls-s\fP and \fBping-s\fP) that immediately start processing and outputing the data line-by-line as JSON Lines (aka NDJSON) while it is being received from \fBSTDIN\fP. This can significantly reduce the amount of memory required to parse large amounts of command output (e.g. \fBls -lR /\fP) and can sometimes process the data more quickly. Streaming parsers have slightly different behavior than standard parsers as outlined below.

--- a/templates/readme_template
+++ b/templates/readme_template
@@ -110,6 +110,7 @@ The JSON output can be compact (default) or pretty formatted with the `-p` optio
 
 ### Options
 - `-a` about `jc`. Prints information about `jc` and the parsers (in JSON, of course!)
+- `-C` force color output even when using pipes (overrides `-m` and the `NO_COLOR` env variable)
 - `-d` debug mode. Prints trace messages if parsing issues are encountered (use `-dd` for verbose debugging)
 - `-h` help. Use `jc -h --parser_name` for parser documentation
 - `-m` monochrome JSON output

--- a/templates/readme_template
+++ b/templates/readme_template
@@ -149,6 +149,9 @@ or
 JC_COLORS=default,default,default,default
 ```
 
+### Disable Colors via Environment Variable
+You can set the [`NO_COLOR`](http://no-color.org/) environment variable to any value to disable color output in `jc`. Note that using the `-C` option to force color output will override both the `NO_COLOR` environment variable and the `-m` option.
+
 ### Streaming Parsers
 Most parsers load all of the data from STDIN, parse it, then output the entire JSON document serially. There are some streaming parsers (e.g. `ls-s` and `ping-s`) that immediately start processing and outputing the data line-by-line as [JSON Lines](https://jsonlines.org/) (aka [NDJSON](http://ndjson.org/)) while it is being received from STDIN. This can significantly reduce the amount of memory required to parse large amounts of command output (e.g. `ls -lR /`) and can sometimes process the data more quickly. Streaming parsers have slightly different behavior than standard parsers as outlined below.
 


### PR DESCRIPTION
- Add support for the NO_COLOR environment variable to set mono (http://no-color.org/)
- Add -C option to force color output even when using pipes (overrides -m and NO_COLOR)