### PR TITLE
Update name of alternative from name to alternative

### DIFF
--- a/jc/parsers/update_alt_q.py
+++ b/jc/parsers/update_alt_q.py
@@ -30,7 +30,7 @@ Schema:
       "value":                string,   # (null if 'none')
       "alternatives": [
         {
-          "name":             string,
+          "alternative":             string,
           "priority":         integer,
           "slaves": [
             {
@@ -63,7 +63,7 @@ Examples:
       "value": "/bin/nano",
       "alternatives": [
         {
-          "name": "/bin/ed",
+          "alternative": "/bin/ed",
           "priority": -100,
           "slaves": [
             {
@@ -73,7 +73,7 @@ Examples:
           ]
         },
         {
-          "name": "/bin/nano",
+          "alternative": "/bin/nano",
           "priority": 40,
           "slaves": [
             {
@@ -104,7 +104,7 @@ Examples:
       "value": "/bin/nano",
       "alternatives": [
         {
-          "name": "/bin/ed",
+          "alternative": "/bin/ed",
           "priority": "-100",
           "slaves": [
             {
@@ -114,7 +114,7 @@ Examples:
           ]
         },
         {
-          "name": "/bin/nano",
+          "alternative": "/bin/nano",
           "priority": "40",
           "slaves": [
             {
@@ -246,7 +246,7 @@ def parse(
                     raw_output['alternatives'].append(alt_obj)
                     slaves = []
 
-                alt_obj = {"name": line_list[1]}
+                alt_obj = {"alternative": line_list[1]}
                 continue
 
             if line.startswith('Priority: '):

--- a/jc/parsers/update_alt_q.py
+++ b/jc/parsers/update_alt_q.py
@@ -30,7 +30,7 @@ Schema:
       "value":                string,   # (null if 'none')
       "alternatives": [
         {
-          "alternative":             string,
+          "alternative":      string,
           "priority":         integer,
           "slaves": [
             {


### PR DESCRIPTION
Update the `update-alternatives --query` parser as discussed in [this thread](https://github.com/kellyjonbrazil/jc/issues/230) so the JSON is a closer match for the `update-alternatives --query` plain text output.