### PR TITLE
id: parse output without name

### DIFF
--- a/jc/parsers/id.py
+++ b/jc/parsers/id.py
@@ -105,7 +105,7 @@ import jc.utils
 
 class info():
     """Provides parser metadata (version, author, etc.)"""
-    version = '1.4'
+    version = '1.5'
     description = '`id` command parser'
     author = 'Kelly Brazil'
     author_email = 'kellyjonbrazil@gmail.com'
@@ -158,6 +158,12 @@ def parse(data, raw=False, quiet=False):
 
         Dictionary. Raw or processed structured data.
     """
+    def _get_item(list, index, default=None):
+      if index < len(list):
+        return list[index]
+
+      return default
+
     jc.utils.compatibility(__name__, info.compatible, quiet)
     jc.utils.input_type_check(data)
 
@@ -174,14 +180,14 @@ def parse(data, raw=False, quiet=False):
                 uid_parsed = uid_parsed.split('=')
                 raw_output['uid'] = {}
                 raw_output['uid']['id'] = uid_parsed[1]
-                raw_output['uid']['name'] = uid_parsed[2]
+                raw_output['uid']['name'] = _get_item(uid_parsed, 2)
 
             if section.startswith('gid'):
                 gid_parsed = section.replace('(', '=').replace(')', '=')
                 gid_parsed = gid_parsed.split('=')
                 raw_output['gid'] = {}
                 raw_output['gid']['id'] = gid_parsed[1]
-                raw_output['gid']['name'] = gid_parsed[2]
+                raw_output['gid']['name'] = _get_item(gid_parsed, 2)
 
             if section.startswith('groups'):
                 groups_parsed = section.replace('(', '=').replace(')', '=')
@@ -193,7 +199,7 @@ def parse(data, raw=False, quiet=False):
                     group_dict = {}
                     grp_parsed = group.split('=')
                     group_dict['id'] = grp_parsed[0]
-                    group_dict['name'] = grp_parsed[1]
+                    group_dict['name'] = _get_item(grp_parsed, 1)
                     raw_output['groups'].append(group_dict)
 
             if section.startswith('context'):

--- a/tests/test_id.py
+++ b/tests/test_id.py
@@ -29,6 +29,20 @@ class MyTests(unittest.TestCase):
         """
         self.assertEqual(jc.parsers.id.parse('', quiet=True), {})
 
+    def test_id_no_name(self):
+        """
+        Test 'id' with no name
+        """
+        self.assertEqual(
+            jc.parsers.id.parse('uid=1000 gid=1000 groups=1000,10', quiet=True),
+            {'uid': {'id': 1000, 'name': None}, 'gid': {'id': 1000, 'name': None}, 'groups': [{'id': 1000, 'name': None}, {'id': 10, 'name': None}]}
+        )
+
+        self.assertEqual(
+            jc.parsers.id.parse('uid=1000(user) gid=1000 groups=1000,10(wheel)', quiet=True),
+            {'uid': {'id': 1000, 'name': 'user'}, 'gid': {'id': 1000, 'name': None}, 'groups': [{'id': 1000, 'name': None}, {'id': 10, 'name': 'wheel'}]}
+        )
+
     def test_id_centos_7_7(self):
         """
         Test 'id' on Centos 7.7


### PR DESCRIPTION
If a group does not exist only gid is present in the command output.