### PR TITLE
fix url parser for urls ending in slash

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 jc changelog
 
+20220723 v1.20.4
+- Fix URL string parser path list for URLs ending in a forward slash
+
 20220723 v1.20.3
 - Add URL string parser
 - Add Email Address string parser

--- a/jc/lib.py
+++ b/jc/lib.py
@@ -6,7 +6,7 @@ import importlib
 from typing import Dict, List, Iterable, Union, Iterator
 from jc import appdirs
 
-__version__ = '1.20.3'
+__version__ = '1.20.4'
 
 parsers = [
     'acpi',

--- a/jc/parsers/url.py
+++ b/jc/parsers/url.py
@@ -318,14 +318,14 @@ def parse(
             encoded_path_list = encoded_path.replace('/', '', 1).split('/')
             decoded_path_list = decoded_path.replace('/', '', 1).split('/')
 
-            if path_list == ['']:
-                path_list = None
+            if path_list[-1] == '':
+                path_list.pop()
 
-            if encoded_path_list == ['']:
-                encoded_path_list = None
+            if encoded_path_list[-1] == '':
+                encoded_path_list.pop()
 
-            if decoded_path_list == ['']:
-                decoded_path_list = None
+            if decoded_path_list[-1] == '':
+                decoded_path_list.pop()
 
         if normalized.query:
             query_obj = parse_qs(normalized.query)

--- a/man/jc.1
+++ b/man/jc.1
@@ -1,4 +1,4 @@
-.TH jc 1 2022-07-23 1.20.3 "JSON Convert"
+.TH jc 1 2022-07-23 1.20.4 "JSON Convert"
 .SH NAME
 \fBjc\fP \- JSON Convert JSONifies the output of many CLI tools and file-types
 .SH SYNOPSIS

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as f:
 
 setuptools.setup(
     name='jc',
-    version='1.20.3',
+    version='1.20.4',
     author='Kelly Brazil',
     author_email='kellyjonbrazil@gmail.com',
     description='Converts the output of popular command-line tools and file-types to JSON.',

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -92,5 +92,32 @@ class MyTests(unittest.TestCase):
         self.assertEqual(jc.parsers.url.parse(data, quiet=True), expected)
 
 
+    def test_http_path_ends_in_slash(self):
+        """
+        Test HTTP URL with a forward slash as the last part of the path
+        """
+        data = r'https://pypi.org/project/jc/1.20.3/'
+        expected = json.loads(r'''{"url":"https://pypi.org/project/jc/1.20.3/","scheme":"https","netloc":"pypi.org","path":"/project/jc/1.20.3/","path_list":["project","jc","1.20.3"],"query":null,"query_obj":null,"fragment":null,"username":null,"password":null,"hostname":"pypi.org","port":null,"encoded":{"url":"https://pypi.org/project/jc/1.20.3/","scheme":"https","netloc":"pypi.org","path":"/project/jc/1.20.3/","path_list":["project","jc","1.20.3"],"query":null,"fragment":null,"username":null,"password":null,"hostname":"pypi.org","port":null},"decoded":{"url":"https://pypi.org/project/jc/1.20.3/","scheme":"https","netloc":"pypi.org","path":"/project/jc/1.20.3/","path_list":["project","jc","1.20.3"],"query":null,"fragment":null,"username":null,"password":null,"hostname":"pypi.org","port":null}}''')
+        self.assertEqual(jc.parsers.url.parse(data, quiet=True), expected)
+
+
+    def test_http_path_only_slash(self):
+        """
+        Test HTTP URL with a forward slash as the last only part of the path
+        """
+        data = r'https://pypi.org/'
+        expected = json.loads(r'''{"url":"https://pypi.org/","scheme":"https","netloc":"pypi.org","path":"/","path_list":null,"query":null,"query_obj":null,"fragment":null,"username":null,"password":null,"hostname":"pypi.org","port":null,"encoded":{"url":"https://pypi.org/","scheme":"https","netloc":"pypi.org","path":"/","path_list":null,"query":null,"fragment":null,"username":null,"password":null,"hostname":"pypi.org","port":null},"decoded":{"url":"https://pypi.org/","scheme":"https","netloc":"pypi.org","path":"/","path_list":null,"query":null,"fragment":null,"username":null,"password":null,"hostname":"pypi.org","port":null}}''')
+        self.assertEqual(jc.parsers.url.parse(data, quiet=True), expected)
+
+
+    def test_http_path_no_end_slash(self):
+        """
+        Test HTTP URL with no forward slash at the end
+        """
+        data = r'https://pypi.org'
+        expected = json.loads(r'''{"url":"https://pypi.org","scheme":"https","netloc":"pypi.org","path":null,"path_list":null,"query":null,"query_obj":null,"fragment":null,"username":null,"password":null,"hostname":"pypi.org","port":null,"encoded":{"url":"https://pypi.org","scheme":"https","netloc":"pypi.org","path":null,"path_list":null,"query":null,"fragment":null,"username":null,"password":null,"hostname":"pypi.org","port":null},"decoded":{"url":"https://pypi.org","scheme":"https","netloc":"pypi.org","path":null,"path_list":null,"query":null,"fragment":null,"username":null,"password":null,"hostname":"pypi.org","port":null}}''')
+        self.assertEqual(jc.parsers.url.parse(data, quiet=True), expected)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- Fix URL string parser path list for URLs ending in a forward slash