### PR TITLE
fix for ipv6 ip-address parser with older python and version bump

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,12 @@
 jc changelog
 
+20220829 v1.21.2
+- Fix IP Address string parser for older python versions that don't cleanly
+  accept decimal input format - IPv6 fix (e.g. python 3.6)
+
 20220828 v1.21.1
 - Fix IP Address string parser for older python versions that don't cleanly
-  accept decimal input format (e.g. python 3.6)
+  accept decimal input format - IPv4 fix (e.g. python 3.6)
 - Fix `arp -a` parser for cases where incomplete hardware addresses are found
   in the arp table on linux
 

--- a/docs/parsers/ip_address.md
+++ b/docs/parsers/ip_address.md
@@ -487,4 +487,4 @@ Returns:
 ### Parser Information
 Compatibility:  linux, darwin, cygwin, win32, aix, freebsd
 
-Version 1.1 by Kelly Brazil (kellyjonbrazil@gmail.com)
+Version 1.2 by Kelly Brazil (kellyjonbrazil@gmail.com)

--- a/jc/lib.py
+++ b/jc/lib.py
@@ -6,7 +6,7 @@ import importlib
 from typing import Dict, List, Iterable, Union, Iterator
 from jc import appdirs
 
-__version__ = '1.21.1'
+__version__ = '1.21.2'
 
 parsers = [
     'acpi',

--- a/jc/parsers/ip_address.py
+++ b/jc/parsers/ip_address.py
@@ -468,7 +468,7 @@ import jc.utils
 
 class info():
     """Provides parser metadata (version, author, etc.)"""
-    version = '1.1'
+    version = '1.2'
     description = 'IPv4 and IPv6 Address string parser'
     author = 'Kelly Brazil'
     author_email = 'kellyjonbrazil@gmail.com'
@@ -569,7 +569,10 @@ def parse(
         try:
             hostmask_string = str(interface.hostmask)
         except AttributeError:
-            hostmask_string = '0.0.0.0'
+            if interface.version == 4:
+                hostmask_string = '0.0.0.0'
+            if interface.version == 6:
+                hostmask_string = '::'
 
         hostmask_ipobj = ipaddress.ip_address(hostmask_string)
 
@@ -577,7 +580,10 @@ def parse(
         try:
             netmask_string = str(interface.netmask)
         except AttributeError:
-            netmask_string = '255.255.255.255'
+            if interface.version == 4:
+                netmask_string = '255.255.255.255'
+            if interface.version == 6:
+                netmask_string = 'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff'
 
         netmask_ipobj = ipaddress.ip_address(netmask_string)
 

--- a/man/jc.1
+++ b/man/jc.1
@@ -1,4 +1,4 @@
-.TH jc 1 2022-08-28 1.21.1 "JSON Convert"
+.TH jc 1 2022-08-29 1.21.2 "JSON Convert"
 .SH NAME
 \fBjc\fP \- JSON Convert JSONifies the output of many CLI tools and file-types
 .SH SYNOPSIS

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as f:
 
 setuptools.setup(
     name='jc',
-    version='1.21.1',
+    version='1.21.2',
     author='Kelly Brazil',
     author_email='kellyjonbrazil@gmail.com',
     description='Converts the output of popular command-line tools and file-types to JSON.',


### PR DESCRIPTION
- Fix IP Address string parser for older python versions that don't cleanly accept decimal input format - IPv6 fix (e.g. python 3.6)