### PR TITLE
id: support space in names

### DIFF
--- a/jc/parsers/id.py
+++ b/jc/parsers/id.py
@@ -106,7 +106,7 @@ import jc.utils
 
 class info():
     """Provides parser metadata (version, author, etc.)"""
-    version = '1.5'
+    version = '1.6'
     description = '`id` command parser'
     author = 'Kelly Brazil'
     author_email = 'kellyjonbrazil@gmail.com'

--- a/jc/parsers/id.py
+++ b/jc/parsers/id.py
@@ -100,6 +100,7 @@ Examples:
       }
     }
 """
+import re
 import jc.utils
 
 
@@ -170,28 +171,28 @@ def parse(data, raw=False, quiet=False):
 
     raw_output = {}
 
-    # Clear any blank lines
-    cleandata = list(filter(None, data.split()))
+    # re.split produces first element empty
+    cleandata = re.split(r' ?(uid|gid|groups|context)=', data.strip())[1:]
 
     if jc.utils.has_data(data):
 
-        for section in cleandata:
-            if section.startswith('uid'):
-                uid_parsed = section.replace('(', '=').replace(')', '=')
+        for key, value in zip(cleandata[0::2], cleandata[1::2]):
+            if key == 'uid':
+                uid_parsed = value.replace('(', '=').replace(')', '=')
                 uid_parsed = uid_parsed.split('=')
                 raw_output['uid'] = {}
-                raw_output['uid']['id'] = uid_parsed[1]
-                raw_output['uid']['name'] = _get_item(uid_parsed, 2)
+                raw_output['uid']['id'] = uid_parsed[0]
+                raw_output['uid']['name'] = _get_item(uid_parsed, 1)
 
-            if section.startswith('gid'):
-                gid_parsed = section.replace('(', '=').replace(')', '=')
+            if key == 'gid':
+                gid_parsed = value.replace('(', '=').replace(')', '=')
                 gid_parsed = gid_parsed.split('=')
                 raw_output['gid'] = {}
-                raw_output['gid']['id'] = gid_parsed[1]
-                raw_output['gid']['name'] = _get_item(gid_parsed, 2)
+                raw_output['gid']['id'] = gid_parsed[0]
+                raw_output['gid']['name'] = _get_item(gid_parsed, 1)
 
-            if section.startswith('groups'):
-                groups_parsed = section.replace('(', '=').replace(')', '=')
+            if key == 'groups':
+                groups_parsed = value.replace('(', '=').replace(')', '=')
                 groups_parsed = groups_parsed.replace('groups=', '')
                 groups_parsed = groups_parsed.split(',')
                 raw_output['groups'] = []
@@ -203,9 +204,8 @@ def parse(data, raw=False, quiet=False):
                     group_dict['name'] = _get_item(grp_parsed, 1)
                     raw_output['groups'].append(group_dict)
 
-            if section.startswith('context'):
-                context_parsed = section.replace('context=', '')
-                context_parsed = context_parsed.split(':', maxsplit=3)
+            if key == 'context':
+                context_parsed = value.split(':', maxsplit=3)
                 raw_output['context'] = {}
                 raw_output['context']['user'] = context_parsed[0]
                 raw_output['context']['role'] = context_parsed[1]

--- a/tests/test_id.py
+++ b/tests/test_id.py
@@ -43,6 +43,30 @@ class MyTests(unittest.TestCase):
             {'uid': {'id': 1000, 'name': 'user'}, 'gid': {'id': 1000, 'name': None}, 'groups': [{'id': 1000, 'name': None}, {'id': 10, 'name': 'wheel'}]}
         )
 
+    def test_id_space(self):
+        """
+        Test 'id' with with space in name
+        """
+        self.assertEqual(
+            jc.parsers.id.parse('uid=1000(user 1) gid=1000 groups=1000,10(wheel)', quiet=True),
+            {'uid': {'id': 1000, 'name': 'user 1'}, 'gid': {'id': 1000, 'name': None}, 'groups': [{'id': 1000, 'name': None}, {'id': 10, 'name': 'wheel'}]}
+        )
+
+        self.assertEqual(
+            jc.parsers.id.parse('uid=1000(user) gid=1000(group 1) groups=1000,10(wheel)', quiet=True),
+            {'uid': {'id': 1000, 'name': 'user'}, 'gid': {'id': 1000, 'name': 'group 1'}, 'groups': [{'id': 1000, 'name': None}, {'id': 10, 'name': 'wheel'}]}
+        )
+
+        self.assertEqual(
+            jc.parsers.id.parse('uid=1000(user) gid=1000 groups=1000,10(wheel 1)', quiet=True),
+            {'uid': {'id': 1000, 'name': 'user'}, 'gid': {'id': 1000, 'name': None}, 'groups': [{'id': 1000, 'name': None}, {'id': 10, 'name': 'wheel 1'}]}
+        )
+
+        self.assertEqual(
+            jc.parsers.id.parse('uid=1000(user 1) gid=1000(group 1) groups=1000,10(wheel 1)', quiet=True),
+            {'uid': {'id': 1000, 'name': 'user 1'}, 'gid': {'id': 1000, 'name': 'group 1'}, 'groups': [{'id': 1000, 'name': None}, {'id': 10, 'name': 'wheel 1'}]}
+        )
+
     def test_id_centos_7_7(self):
         """
         Test 'id' on Centos 7.7


### PR DESCRIPTION
id parser did not work correctly if space is present in user or group
name.