### PR TITLE
iwconfig : relax regex to match interface

### DIFF
--- a/jc/parsers/iwconfig.py
+++ b/jc/parsers/iwconfig.py
@@ -119,6 +119,7 @@ def _process(proc_data: List[JSONDictType]) -> List[JSONDictType]:
     proc_data = [ { key: int(value) if key in int_list else value for key, value in proc_data_item.items() } for proc_data_item in proc_data ]
     proc_data = [ { key: float(value) if key in float_list else value for key, value in proc_data_item.items() } for proc_data_item in proc_data ]
     proc_data = [ { key: value == 'on' if key in bool_list else value for key, value in proc_data_item .items() } for proc_data_item in proc_data ]
+    proc_data = [ { key: value.strip() if isinstance(value, str) else value for key, value in proc_data_item .items() } for proc_data_item in proc_data ]
 
     return proc_data
 

--- a/jc/parsers/iwconfig.py
+++ b/jc/parsers/iwconfig.py
@@ -146,7 +146,7 @@ def parse(
 
     raw_output: List[Dict] = []
 
-    re_interface = re.compile(r'^(?P<name>[a-zA-Z0-9:._-]+)\s+(?P<protocol>([a-zA-Z0-9]+\s)*[a-zA-Z0-9.]+)\s+ESSID:\"(?P<essid>[a-zA-Z0-9:._\s]+)\"')
+    re_interface = re.compile(r'^(?P<name>\S+)\s+(?P<protocol>.*)\s+ESSID:\"(?P<essid>.*)\"')
     re_mode = re.compile(r'Mode:(?P<mode>\w+)')
     re_frequency = re.compile(r'Frequency:(?P<frequency>[0-9.]+)\s(?P<frequency_unit>\w+)')
     re_access_point = re.compile(r'Access Point:\s*(?P<access_point>[0-9A-F:]+)')


### PR DESCRIPTION
I encountered real-life examples where the interface was not matching so the parser return nothing.
I think it could be way more relaxed and remain safe.