### PR TITLE
Fix typos

### DIFF
--- a/docs/parsers/ver.md
+++ b/docs/parsers/ver.md
@@ -7,7 +7,7 @@ jc - JSON Convert Version string output parser
 
 Best-effort attempt to parse various styles of version numbers. This parser
 is based off of the version parser included in the CPython distutils
-libary.
+library.
 
 If the version string conforms to some de facto-standard versioning rules
 followed by many developers a `strict` key will be present in the output

--- a/jc/parsers/crontab.py
+++ b/jc/parsers/crontab.py
@@ -198,7 +198,7 @@ def _process(proc_data):
 
         Dictionary. Structured data to conform to the schema.
     """
-    # put itmes in lists
+    # put items in lists
     try:
         for entry in proc_data['schedule']:
             entry['minute'] = entry['minute'].split(',')

--- a/jc/parsers/crontab_u.py
+++ b/jc/parsers/crontab_u.py
@@ -194,7 +194,7 @@ def _process(proc_data):
 
         Dictionary. Structured data to conform to the schema.
     """
-    # put itmes in lists
+    # put items in lists
     try:
         for entry in proc_data['schedule']:
             entry['minute'] = entry['minute'].split(',')

--- a/jc/parsers/mount.py
+++ b/jc/parsers/mount.py
@@ -160,7 +160,7 @@ def _aix_parse(data):
 
         # AIX mount entries have the remote node as the zeroth element. If the
         # mount is local, the zeroth element is the filesystem instead. We can
-        # detect this by the lenth of the list. For local mounts, length is 7,
+        # detect this by the length of the list. For local mounts, length is 7,
         # and for remote mounts, the length is 8. In the remote case, pop off
         # the zeroth element. Then parsed_line has a consistent format.
         if len(parsed_line) == 8:

--- a/jc/parsers/route.py
+++ b/jc/parsers/route.py
@@ -214,7 +214,7 @@ def parse(data, raw=False, quiet=False):
 
     if jc.utils.has_data(data):
         import jc.parsers.route_windows
-        if cleandata[0] in jc.parsers.route_windows.SEPERATORS:
+        if cleandata[0] in jc.parsers.route_windows.SEPARATORS:
            raw_output = jc.parsers.route_windows.parse(cleandata)
         else:
           cleandata.pop(0)  # Removing "Kernel IP routing table".

--- a/jc/parsers/route_windows.py
+++ b/jc/parsers/route_windows.py
@@ -6,7 +6,7 @@
 import re
 from typing import List
 
-SEPERATORS = (
+SEPARATORS = (
     "===========================================================================",
     "  None"
 )
@@ -24,7 +24,7 @@ ROUTE_TYPES = ("Active Routes:", "Persistent Routes:")
 def get_lines_until_seperator(iterator):
     lines = []
     for line in iterator:
-        if line in SEPERATORS:
+        if line in SEPARATORS:
             break
         lines.append(line)
     return lines
@@ -86,7 +86,7 @@ def parse(cleandata: List[str]):
             interfaces = []
             for interface_line in data_iterator:
                 interface_line = interface_line.strip()
-                if interface_line in SEPERATORS:
+                if interface_line in SEPARATORS:
                     break
 
                 interface_match = INTERFACE_REGEX.search(interface_line)

--- a/jc/parsers/ver.py
+++ b/jc/parsers/ver.py
@@ -2,7 +2,7 @@
 
 Best-effort attempt to parse various styles of version numbers. This parser
 is based off of the version parser included in the CPython distutils
-libary.
+library.
 
 If the version string conforms to some de facto-standard versioning rules
 followed by many developers a `strict` key will be present in the output

--- a/tests/test_mdadm.py
+++ b/tests/test_mdadm.py
@@ -173,7 +173,7 @@ class MyTests(unittest.TestCase):
         mdadm_examine_json = json.loads(f.read())
 
     with open(os.path.join(THIS_DIR, os.pardir, 'tests/fixtures/generic/mdadm-query-detail.json'), 'r', encoding='utf-8') as f:
-        mdadm_query_detial_json = json.loads(f.read())
+        mdadm_query_detail_json = json.loads(f.read())
 
     with open(os.path.join(THIS_DIR, os.pardir, 'tests/fixtures/generic/mdadm-query-raid0-ok.json'), 'r', encoding='utf-8') as f:
         mdadm_query_raid0_ok_json = json.loads(f.read())
@@ -360,7 +360,7 @@ class MyTests(unittest.TestCase):
         """
         Test 'mdadm --query --detail'
         """
-        self.assertEqual(jc.parsers.mdadm.parse(self.mdadm_query_detail, quiet=True), self.mdadm_query_detial_json)
+        self.assertEqual(jc.parsers.mdadm.parse(self.mdadm_query_detail, quiet=True), self.mdadm_query_detail_json)
 
 
     def test_mdadm_query_raid0_ok(self):


### PR DESCRIPTION
Found via `codespell -S ./tests/fixtures -L chage,respons,astroid,unx,ist,technik,ans,buildd`