### PR TITLE
extract to public jc.get_parser(parser_name)

### DIFF
--- a/docs/lib.md
+++ b/docs/lib.md
@@ -1,6 +1,8 @@
 # Table of Contents
 
 * [jc.lib](#jc.lib)
+  * [data\_dir](#jc.lib.data_dir)
+  * [get\_parser](#jc.lib.get_parser)
   * [parse](#jc.lib.parse)
   * [parser\_mod\_list](#jc.lib.parser_mod_list)
   * [plugin\_parser\_mod\_list](#jc.lib.plugin_parser_mod_list)
@@ -16,6 +18,26 @@
 # jc.lib
 
 jc - JSON Convert lib module
+
+<a id="jc.lib.get_parser"></a>
+
+### get\_parser
+
+```python
+def get_parser(parser_mod_name) -> ModuleType
+```
+
+Return the parser module object
+
+Parameters:
+
+    parser_mod_name:    (string or   name of the parser module. This
+                        Module)      function will accept module_name,
+                                     cli-name, and --argument-name
+                                     variants of the module name.
+Returns:
+
+    Parser: the parser module object
 
 <a id="jc.lib.parse"></a>
 

--- a/docs/lib.md
+++ b/docs/lib.md
@@ -1,7 +1,6 @@
 # Table of Contents
 
 * [jc.lib](#jc.lib)
-  * [data\_dir](#jc.lib.data_dir)
   * [get\_parser](#jc.lib.get_parser)
   * [parse](#jc.lib.parse)
   * [parser\_mod\_list](#jc.lib.parser_mod_list)

--- a/jc/__init__.py
+++ b/jc/__init__.py
@@ -127,6 +127,7 @@ Get a list of streaming parser module names to be used in
 from .lib import (
     __version__ as __version__,
     parse as parse,
+    get_parser as get_parser,
     parser_mod_list as parser_mod_list,
     plugin_parser_mod_list as plugin_parser_mod_list,
     standard_parser_mod_list as standard_parser_mod_list,
@@ -134,6 +135,5 @@ from .lib import (
     slurpable_parser_mod_list as slurpable_parser_mod_list,
     parser_info as parser_info,
     all_parser_info as all_parser_info,
-    get_help as get_help,
-    get_parser as get_parser
+    get_help as get_help
 )

--- a/jc/__init__.py
+++ b/jc/__init__.py
@@ -134,5 +134,6 @@ from .lib import (
     slurpable_parser_mod_list as slurpable_parser_mod_list,
     parser_info as parser_info,
     all_parser_info as all_parser_info,
-    get_help as get_help
+    get_help as get_help,
+    get_parser as get_parser
 )

--- a/jc/cli.py
+++ b/jc/cli.py
@@ -6,7 +6,6 @@ import io
 import sys
 import os
 import re
-from itertools import islice
 from datetime import datetime, timezone
 import textwrap
 import shlex
@@ -45,8 +44,6 @@ JC_ERROR_EXIT: int = 100
 MAX_EXIT: int = 255
 SLICER_PATTERN: str = r'-?[0-9]*\:-?[0-9]*$'
 SLICER_RE = re.compile(SLICER_PATTERN)
-NEWLINES_PATTERN: str = r'(\r\n|\r|\n)'
-NEWLINES_RE = re.compile(NEWLINES_PATTERN)
 
 
 class info():

--- a/jc/lib.py
+++ b/jc/lib.py
@@ -270,6 +270,13 @@ def _parser_argument(parser_mod_name: str) -> str:
     parser = _modname_to_cliname(parser_mod_name)
     return f'--{parser}'
 
+def get_parser(parser_mod_name) -> ModuleType:
+    if isinstance(parser_mod_name, ModuleType):
+        jc_parser = parser_mod_name
+    else:
+        jc_parser = _get_parser(parser_mod_name)
+    return jc_parser
+
 def _get_parser(parser_mod_name: str) -> ModuleType:
     """Return the parser module object"""
     # ensure parser_mod_name is a true module name and not a cli name
@@ -409,10 +416,7 @@ def parse(
         Standard Parsers:   Dictionary or List of Dictionaries
         Streaming Parsers:  Generator Object containing Dictionaries
     """
-    if isinstance(parser_mod_name, ModuleType):
-        jc_parser = parser_mod_name
-    else:
-        jc_parser = _get_parser(parser_mod_name)
+    jc_parser = get_parser(parser_mod_name)
 
     if ignore_exceptions is not None:
         return jc_parser.parse(

--- a/jc/lib.py
+++ b/jc/lib.py
@@ -271,6 +271,21 @@ def _parser_argument(parser_mod_name: str) -> str:
     return f'--{parser}'
 
 def get_parser(parser_mod_name) -> ModuleType:
+    """
+    Return the parser module object
+
+    Parameters:
+
+        parser_mod_name:    (string or   name of the parser module. This
+                            Module)      function will accept module_name,
+                                         cli-name, and --argument-name
+                                         variants of the module name.
+    Returns:
+
+        Parser: the parser module object
+
+
+    """
     if isinstance(parser_mod_name, ModuleType):
         jc_parser = parser_mod_name
     else:


### PR DESCRIPTION
extract to public `jc.get_parser(parser_name)`

still now it is only possible to do a:

```python
for data in data_list:
	jc.parse(parser_name, data, quiet=True),
```

with `get_parser` this is possible:

```python
my_parser = jc.get_parser(parser_name)
for data in data_list:
	my_parser.parse(data, quiet=True),
```

TODO:
- [ ] docs
