### PR TITLE
fix: crontab remove double entry in doc

### DIFF
--- a/docs/parsers/crontab.md
+++ b/docs/parsers/crontab.md
@@ -32,7 +32,6 @@ Schema:
       ],
       "schedule": [
         {
-          "occurrence"        string,
           "minute": [
                               string
           ],

--- a/jc/parsers/crontab.py
+++ b/jc/parsers/crontab.py
@@ -27,7 +27,6 @@ Schema:
       ],
       "schedule": [
         {
-          "occurrence"        string,
           "minute": [
                               string
           ],


### PR DESCRIPTION
fix: 
- crontab parser: remove double entry in doc