### PR TITLE
[dependency] Add typing extensions and EOLs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 ruamel.yaml>=0.15.0
 xmltodict>=0.12.0
 Pygments>=2.3.0
+typing_extensions>=4.9.0


### PR DESCRIPTION
I'd like to add the package typing_extensions. 

It's [maintained by the Python team](https://github.com/python/typing_extensions) itself to backport new types and peps that eventually land in `typing`.

In my recent PR this is useful for typing.TypedDict (3.8) and typing.Self (3.11).

We may be able to uninstall it as versions < 3.11 go EOL.

Also, I wanted to discuss removing builds for 3.6 and 3.7, [EOL in 2021 and 2023 respectively](https://devguide.python.org/versions/)