### PR TITLE
add "sudo efibootmgr" (without -v) output test case

### DIFF
--- a/tests/fixtures/create_fixtures.sh
+++ b/tests/fixtures/create_fixtures.sh
@@ -8,7 +8,8 @@ df -h    > df-h.out
 dig www.google.com AAAA        > dig-aaaa.out
 dig www.cnn.com www.google.com > dig.out
 dig -x 1.1.1.1                 > dig-x.out
-sudo efibootmgr -v > efibootmgr.out
+sudo efibootmgr > efibootmgr.out
+sudo efibootmgr -v > efibootmgr-v.out
 env      > env.out
 free     > free.out
 free -h  > free-h.out

--- a/tests/fixtures/opensuse-leap-15.5/efibootmgr-v.json
+++ b/tests/fixtures/opensuse-leap-15.5/efibootmgr-v.json
@@ -1,0 +1,96 @@
+[
+    {
+        "boot_current": "0004",
+        "timeout_seconds": 0,
+        "boot_order": [
+            "0004",
+            "0001",
+            "0007",
+            "0002",
+            "0003",
+            "0009",
+            "0000",
+            "0005",
+            "0006",
+            "0008",
+            "000A",
+            "000B"
+        ],
+        "mirrored_percentage_above_4g": 0.0,
+        "mirror_memory_below_4gb": false,
+        "boot_options": [
+            {
+                "boot_option_reference": "Boot0000",
+                "display_name": "debian",
+                "uefi_device_path": "HD(1,GPT,66b2a325-3129-45d3-84dd-c1a4e4bd846b,0x800,0x100000)/File(\\EFI\\debian\\shimx64.efi)",
+                "boot_option_enabled": true
+            },
+            {
+                "boot_option_reference": "Boot0001",
+                "display_name": "RecoveryBoot",
+                "uefi_device_path": "HD(3,GPT,a75ab570-de77-504c-be97-35faa629f1f3,0x5dc800,0x1f4000)/File(EFI\\boot\\bootx64.efi)",
+                "boot_option_enabled": true
+            },
+            {
+                "boot_option_reference": "Boot0002",
+                "display_name": "Embedded NIC 1 Port 1 Partition 1",
+                "uefi_device_path": "VenHw(3a191845-5f86-4e78-8fce-c4cff59f9daa)",
+                "boot_option_enabled": false
+            },
+            {
+                "boot_option_reference": "Boot0003",
+                "display_name": "Embedded NIC 2 Port 1 Partition 1",
+                "uefi_device_path": "VenHw(d227c733-f75f-4341-b749-4d1759ec8538)",
+                "boot_option_enabled": false
+            },
+            {
+                "boot_option_reference": "Boot0004",
+                "display_name": "PrimaryBoot",
+                "uefi_device_path": "HD(1,GPT,faf946be-a174-478f-82ea-d90aa476fb91,0x800,0xfa000)/File(EFI\\boot\\bootx64.efi)",
+                "boot_option_enabled": true
+            },
+            {
+                "boot_option_reference": "Boot0005",
+                "display_name": "EFI Fixed Disk Boot Device 3",
+                "uefi_device_path": "PciRoot(0x1)/Pci(0x4,0x0)/Pci(0x0,0x0)/NVMe(0x1,8C-E3-8E-E2-0A-D4-0F-01)/HD(1,GPT,c2336d30-9bde-4a0b-b9be-145d6958d5af,0x1000,0x80001)",
+                "boot_option_enabled": true
+            },
+            {
+                "boot_option_reference": "Boot0006",
+                "display_name": "EFI Fixed Disk Boot Device 4",
+                "uefi_device_path": "PciRoot(0x11)/Pci(0x1,0x0)/Pci(0x0,0x0)/NVMe(0x1,00-25-38-95-21-01-B8-C1)/HD(1,GPT,1fbfeaec-d78d-4d8c-93ae-77bba6c09d3f,0x1000,0x80001)",
+                "boot_option_enabled": true
+            },
+            {
+                "boot_option_reference": "Boot0007",
+                "display_name": "BackendBoot",
+                "uefi_device_path": "PciRoot(0x11)/Pci(0x3,0x0)/Pci(0x0,0x0)/NVMe(0x1,00-25-38-95-21-01-B5-B6)/HD(1,GPT,b95c4d58-849f-40fa-bf2b-4f0b8a0aa8bd,0x1000,0x80001)",
+                "boot_option_enabled": true
+            },
+            {
+                "boot_option_reference": "Boot0008",
+                "display_name": "EFI Fixed Disk Boot Device 6",
+                "uefi_device_path": "PciRoot(0x11)/Pci(0x6,0x0)/Pci(0x0,0x0)/NVMe(0x1,8C-E3-8E-E2-0A-D3-90-01)/HD(1,GPT,f543ab7b-9d55-4e57-8afe-bdb907428f15,0x1000,0x80001)",
+                "boot_option_enabled": true
+            },
+            {
+                "boot_option_reference": "Boot0009",
+                "display_name": "EFI Fixed Disk Boot Device 7",
+                "uefi_device_path": "PciRoot(0x12)/Pci(0x6,0x0)/Pci(0x0,0x0)/NVMe(0x1,00-25-38-95-21-01-B6-08)/HD(1,GPT,db9522dc-062b-4efa-84b5-6956cea7b5a6,0x1000,0x80001)",
+                "boot_option_enabled": true
+            },
+            {
+                "boot_option_reference": "Boot000A",
+                "display_name": "EFI Fixed Disk Boot Device 8",
+                "uefi_device_path": "PciRoot(0x12)/Pci(0x8,0x0)/Pci(0x0,0x0)/NVMe(0x1,00-25-38-95-21-01-B6-0D)/HD(1,GPT,4a9e1d40-b853-44a0-8d26-a4df6f112dc9,0x1000,0x80001)",
+                "boot_option_enabled": true
+            },
+            {
+                "boot_option_reference": "Boot000B",
+                "display_name": "EFI Fixed Disk Boot Device 9",
+                "uefi_device_path": "PciRoot(0x13)/Pci(0x5,0x0)/Pci(0x0,0x0)/NVMe(0x1,8C-E3-8E-E2-0A-D3-8E-01)/HD(1,GPT,5a80e168-bac7-4967-9507-e23a432bae18,0x1000,0x80001)",
+                "boot_option_enabled": true
+            }
+        ]
+    }
+]

--- a/tests/fixtures/opensuse-leap-15.5/efibootmgr-v.out
+++ b/tests/fixtures/opensuse-leap-15.5/efibootmgr-v.out
@@ -1,0 +1,17 @@
+BootCurrent: 0004
+Timeout: 0 seconds
+BootOrder: 0004,0001,0007,0002,0003,0009,0000,0005,0006,0008,000A,000B
+Boot0000* debian	HD(1,GPT,66b2a325-3129-45d3-84dd-c1a4e4bd846b,0x800,0x100000)/File(\EFI\debian\shimx64.efi)
+Boot0001* RecoveryBoot	HD(3,GPT,a75ab570-de77-504c-be97-35faa629f1f3,0x5dc800,0x1f4000)/File(EFI\boot\bootx64.efi)
+Boot0002  Embedded NIC 1 Port 1 Partition 1	VenHw(3a191845-5f86-4e78-8fce-c4cff59f9daa)
+Boot0003  Embedded NIC 2 Port 1 Partition 1	VenHw(d227c733-f75f-4341-b749-4d1759ec8538)
+Boot0004* PrimaryBoot	HD(1,GPT,faf946be-a174-478f-82ea-d90aa476fb91,0x800,0xfa000)/File(EFI\boot\bootx64.efi)
+Boot0005* EFI Fixed Disk Boot Device 3	PciRoot(0x1)/Pci(0x4,0x0)/Pci(0x0,0x0)/NVMe(0x1,8C-E3-8E-E2-0A-D4-0F-01)/HD(1,GPT,c2336d30-9bde-4a0b-b9be-145d6958d5af,0x1000,0x80001)
+Boot0006* EFI Fixed Disk Boot Device 4	PciRoot(0x11)/Pci(0x1,0x0)/Pci(0x0,0x0)/NVMe(0x1,00-25-38-95-21-01-B8-C1)/HD(1,GPT,1fbfeaec-d78d-4d8c-93ae-77bba6c09d3f,0x1000,0x80001)
+Boot0007* BackendBoot	PciRoot(0x11)/Pci(0x3,0x0)/Pci(0x0,0x0)/NVMe(0x1,00-25-38-95-21-01-B5-B6)/HD(1,GPT,b95c4d58-849f-40fa-bf2b-4f0b8a0aa8bd,0x1000,0x80001)
+Boot0008* EFI Fixed Disk Boot Device 6	PciRoot(0x11)/Pci(0x6,0x0)/Pci(0x0,0x0)/NVMe(0x1,8C-E3-8E-E2-0A-D3-90-01)/HD(1,GPT,f543ab7b-9d55-4e57-8afe-bdb907428f15,0x1000,0x80001)
+Boot0009* EFI Fixed Disk Boot Device 7	PciRoot(0x12)/Pci(0x6,0x0)/Pci(0x0,0x0)/NVMe(0x1,00-25-38-95-21-01-B6-08)/HD(1,GPT,db9522dc-062b-4efa-84b5-6956cea7b5a6,0x1000,0x80001)
+Boot000A* EFI Fixed Disk Boot Device 8	PciRoot(0x12)/Pci(0x8,0x0)/Pci(0x0,0x0)/NVMe(0x1,00-25-38-95-21-01-B6-0D)/HD(1,GPT,4a9e1d40-b853-44a0-8d26-a4df6f112dc9,0x1000,0x80001)
+Boot000B* EFI Fixed Disk Boot Device 9	PciRoot(0x13)/Pci(0x5,0x0)/Pci(0x0,0x0)/NVMe(0x1,8C-E3-8E-E2-0A-D3-8E-01)/HD(1,GPT,5a80e168-bac7-4967-9507-e23a432bae18,0x1000,0x80001)
+MirroredPercentageAbove4G: 0.00
+MirrorMemoryBelow4GB: false

--- a/tests/fixtures/opensuse-leap-15.5/efibootmgr.json
+++ b/tests/fixtures/opensuse-leap-15.5/efibootmgr.json
@@ -1,94 +1,28 @@
 [
     {
-        "boot_current": "0004",
+        "boot_current": "0002",
         "timeout_seconds": 0,
         "boot_order": [
-            "0004",
-            "0001",
-            "0007",
             "0002",
-            "0003",
-            "0009",
             "0000",
-            "0005",
-            "0006",
-            "0008",
-            "000A",
-            "000B"
+            "0001"
         ],
         "mirrored_percentage_above_4g": 0.0,
         "mirror_memory_below_4gb": false,
         "boot_options": [
             {
                 "boot_option_reference": "Boot0000",
-                "display_name": "debian",
-                "uefi_device_path": "HD(1,GPT,66b2a325-3129-45d3-84dd-c1a4e4bd846b,0x800,0x100000)/File(\\EFI\\debian\\shimx64.efi)",
+                "display_name": "WARNING",
                 "boot_option_enabled": true
             },
             {
                 "boot_option_reference": "Boot0001",
-                "display_name": "RecoveryBoot",
-                "uefi_device_path": "HD(3,GPT,a75ab570-de77-504c-be97-35faa629f1f3,0x5dc800,0x1f4000)/File(EFI\\boot\\bootx64.efi)",
+                "display_name": "Embedded NIC 1 Port 1 Partition 1",
                 "boot_option_enabled": true
             },
             {
                 "boot_option_reference": "Boot0002",
-                "display_name": "Embedded NIC 1 Port 1 Partition 1",
-                "uefi_device_path": "VenHw(3a191845-5f86-4e78-8fce-c4cff59f9daa)",
-                "boot_option_enabled": false
-            },
-            {
-                "boot_option_reference": "Boot0003",
-                "display_name": "Embedded NIC 2 Port 1 Partition 1",
-                "uefi_device_path": "VenHw(d227c733-f75f-4341-b749-4d1759ec8538)",
-                "boot_option_enabled": false
-            },
-            {
-                "boot_option_reference": "Boot0004",
-                "display_name": "PrimaryBoot",
-                "uefi_device_path": "HD(1,GPT,faf946be-a174-478f-82ea-d90aa476fb91,0x800,0xfa000)/File(EFI\\boot\\bootx64.efi)",
-                "boot_option_enabled": true
-            },
-            {
-                "boot_option_reference": "Boot0005",
-                "display_name": "EFI Fixed Disk Boot Device 3",
-                "uefi_device_path": "PciRoot(0x1)/Pci(0x4,0x0)/Pci(0x0,0x0)/NVMe(0x1,8C-E3-8E-E2-0A-D4-0F-01)/HD(1,GPT,c2336d30-9bde-4a0b-b9be-145d6958d5af,0x1000,0x80001)",
-                "boot_option_enabled": true
-            },
-            {
-                "boot_option_reference": "Boot0006",
-                "display_name": "EFI Fixed Disk Boot Device 4",
-                "uefi_device_path": "PciRoot(0x11)/Pci(0x1,0x0)/Pci(0x0,0x0)/NVMe(0x1,00-25-38-95-21-01-B8-C1)/HD(1,GPT,1fbfeaec-d78d-4d8c-93ae-77bba6c09d3f,0x1000,0x80001)",
-                "boot_option_enabled": true
-            },
-            {
-                "boot_option_reference": "Boot0007",
-                "display_name": "BackendBoot",
-                "uefi_device_path": "PciRoot(0x11)/Pci(0x3,0x0)/Pci(0x0,0x0)/NVMe(0x1,00-25-38-95-21-01-B5-B6)/HD(1,GPT,b95c4d58-849f-40fa-bf2b-4f0b8a0aa8bd,0x1000,0x80001)",
-                "boot_option_enabled": true
-            },
-            {
-                "boot_option_reference": "Boot0008",
-                "display_name": "EFI Fixed Disk Boot Device 6",
-                "uefi_device_path": "PciRoot(0x11)/Pci(0x6,0x0)/Pci(0x0,0x0)/NVMe(0x1,8C-E3-8E-E2-0A-D3-90-01)/HD(1,GPT,f543ab7b-9d55-4e57-8afe-bdb907428f15,0x1000,0x80001)",
-                "boot_option_enabled": true
-            },
-            {
-                "boot_option_reference": "Boot0009",
-                "display_name": "EFI Fixed Disk Boot Device 7",
-                "uefi_device_path": "PciRoot(0x12)/Pci(0x6,0x0)/Pci(0x0,0x0)/NVMe(0x1,00-25-38-95-21-01-B6-08)/HD(1,GPT,db9522dc-062b-4efa-84b5-6956cea7b5a6,0x1000,0x80001)",
-                "boot_option_enabled": true
-            },
-            {
-                "boot_option_reference": "Boot000A",
-                "display_name": "EFI Fixed Disk Boot Device 8",
-                "uefi_device_path": "PciRoot(0x12)/Pci(0x8,0x0)/Pci(0x0,0x0)/NVMe(0x1,00-25-38-95-21-01-B6-0D)/HD(1,GPT,4a9e1d40-b853-44a0-8d26-a4df6f112dc9,0x1000,0x80001)",
-                "boot_option_enabled": true
-            },
-            {
-                "boot_option_reference": "Boot000B",
-                "display_name": "EFI Fixed Disk Boot Device 9",
-                "uefi_device_path": "PciRoot(0x13)/Pci(0x5,0x0)/Pci(0x0,0x0)/NVMe(0x1,8C-E3-8E-E2-0A-D3-8E-01)/HD(1,GPT,5a80e168-bac7-4967-9507-e23a432bae18,0x1000,0x80001)",
+                "display_name": "opensuse-secureboot",
                 "boot_option_enabled": true
             }
         ]

--- a/tests/fixtures/opensuse-leap-15.5/efibootmgr.out
+++ b/tests/fixtures/opensuse-leap-15.5/efibootmgr.out
@@ -1,17 +1,8 @@
-BootCurrent: 0004
+BootCurrent: 0002
 Timeout: 0 seconds
-BootOrder: 0004,0001,0007,0002,0003,0009,0000,0005,0006,0008,000A,000B
-Boot0000* debian	HD(1,GPT,66b2a325-3129-45d3-84dd-c1a4e4bd846b,0x800,0x100000)/File(\EFI\debian\shimx64.efi)
-Boot0001* RecoveryBoot	HD(3,GPT,a75ab570-de77-504c-be97-35faa629f1f3,0x5dc800,0x1f4000)/File(EFI\boot\bootx64.efi)
-Boot0002  Embedded NIC 1 Port 1 Partition 1	VenHw(3a191845-5f86-4e78-8fce-c4cff59f9daa)
-Boot0003  Embedded NIC 2 Port 1 Partition 1	VenHw(d227c733-f75f-4341-b749-4d1759ec8538)
-Boot0004* PrimaryBoot	HD(1,GPT,faf946be-a174-478f-82ea-d90aa476fb91,0x800,0xfa000)/File(EFI\boot\bootx64.efi)
-Boot0005* EFI Fixed Disk Boot Device 3	PciRoot(0x1)/Pci(0x4,0x0)/Pci(0x0,0x0)/NVMe(0x1,8C-E3-8E-E2-0A-D4-0F-01)/HD(1,GPT,c2336d30-9bde-4a0b-b9be-145d6958d5af,0x1000,0x80001)
-Boot0006* EFI Fixed Disk Boot Device 4	PciRoot(0x11)/Pci(0x1,0x0)/Pci(0x0,0x0)/NVMe(0x1,00-25-38-95-21-01-B8-C1)/HD(1,GPT,1fbfeaec-d78d-4d8c-93ae-77bba6c09d3f,0x1000,0x80001)
-Boot0007* BackendBoot	PciRoot(0x11)/Pci(0x3,0x0)/Pci(0x0,0x0)/NVMe(0x1,00-25-38-95-21-01-B5-B6)/HD(1,GPT,b95c4d58-849f-40fa-bf2b-4f0b8a0aa8bd,0x1000,0x80001)
-Boot0008* EFI Fixed Disk Boot Device 6	PciRoot(0x11)/Pci(0x6,0x0)/Pci(0x0,0x0)/NVMe(0x1,8C-E3-8E-E2-0A-D3-90-01)/HD(1,GPT,f543ab7b-9d55-4e57-8afe-bdb907428f15,0x1000,0x80001)
-Boot0009* EFI Fixed Disk Boot Device 7	PciRoot(0x12)/Pci(0x6,0x0)/Pci(0x0,0x0)/NVMe(0x1,00-25-38-95-21-01-B6-08)/HD(1,GPT,db9522dc-062b-4efa-84b5-6956cea7b5a6,0x1000,0x80001)
-Boot000A* EFI Fixed Disk Boot Device 8	PciRoot(0x12)/Pci(0x8,0x0)/Pci(0x0,0x0)/NVMe(0x1,00-25-38-95-21-01-B6-0D)/HD(1,GPT,4a9e1d40-b853-44a0-8d26-a4df6f112dc9,0x1000,0x80001)
-Boot000B* EFI Fixed Disk Boot Device 9	PciRoot(0x13)/Pci(0x5,0x0)/Pci(0x0,0x0)/NVMe(0x1,8C-E3-8E-E2-0A-D3-8E-01)/HD(1,GPT,5a80e168-bac7-4967-9507-e23a432bae18,0x1000,0x80001)
+BootOrder: 0002,0000,0001
+Boot0000* WARNING
+Boot0001* Embedded NIC 1 Port 1 Partition 1
+Boot0002* opensuse-secureboot
 MirroredPercentageAbove4G: 0.00
 MirrorMemoryBelow4GB: false

--- a/tests/test_efibootmgr.py
+++ b/tests/test_efibootmgr.py
@@ -9,10 +9,16 @@ THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 class MyTests(unittest.TestCase):
 
     # input
+    with open(os.path.join(THIS_DIR, os.pardir, 'tests/fixtures/opensuse-leap-15.5/efibootmgr-v.out'), 'r', encoding='utf-8') as f:
+        opensuse_leap_15_5_efibootmgr_v = f.read()
+
     with open(os.path.join(THIS_DIR, os.pardir, 'tests/fixtures/opensuse-leap-15.5/efibootmgr.out'), 'r', encoding='utf-8') as f:
         opensuse_leap_15_5_efibootmgr = f.read()
 
     # output
+    with open(os.path.join(THIS_DIR, os.pardir, 'tests/fixtures/opensuse-leap-15.5/efibootmgr-v.json'), 'r', encoding='utf-8') as f:
+        opensuse_leap_15_5_efibootmgr_json_v = json.loads(f.read())
+
     with open(os.path.join(THIS_DIR, os.pardir, 'tests/fixtures/opensuse-leap-15.5/efibootmgr.json'), 'r', encoding='utf-8') as f:
         opensuse_leap_15_5_efibootmgr_json = json.loads(f.read())
 
@@ -21,6 +27,12 @@ class MyTests(unittest.TestCase):
         Test 'efibootmgr' with no data
         """
         self.assertEqual(jc.parsers.efibootmgr.parse('', quiet=True), [])
+
+    def test_efibootmgr_v_opensuse_leap_15_5(self):
+        """
+        Test 'efibootmgr -v' on Opensuse Leap 15.5
+        """
+        self.assertEqual(jc.parsers.efibootmgr.parse(self.opensuse_leap_15_5_efibootmgr_v, quiet=True), self.opensuse_leap_15_5_efibootmgr_json_v)
 
     def test_efibootmgr_opensuse_leap_15_5(self):
         """


### PR DESCRIPTION
add efibootmgr output test case without -v parameter.
Now we have both `sudo efibootmgr` and `sudo efibootmgr -v` test cases.