### PR TITLE
fix: Edit pythonapp.yml workflow to run on non-draft PRs

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   old_python:
+    if: github.event.pull_request.draft == false
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -37,6 +38,7 @@ jobs:
         python -m unittest discover tests
 
   latest_python:
+    if: github.event.pull_request.draft == false
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
Updated the `pythonapp.yml` workflow to trigger only on non-draft pull requests, ensuring workflows run only when a PR is ready for review or merging.