### PR TITLE
Timezone Testing with TZ Env Variable

### DIFF
--- a/runtests.sh
+++ b/runtests.sh
@@ -2,4 +2,4 @@
 # system should be in "America/Los_Angeles" timezone for all tests to pass
 # ensure no local plugin parsers are installed for all tests to pass
 
-python3 -m unittest -v
+TZ=America/Los_Angeles python3 -m unittest -v


### PR DESCRIPTION
This PR enables timezone-specific testing by using the TZ environment variable. Tests can now run in Los Angeles timezone without changing the system timezone, ensuring isolated and reproducible results.
This change was tested successfully on multiple macOS and Linux machines for compatibility.
Note: The `TZ` environment variable is ignored on Windows systems.