### PR TITLE
Adjust for removal of typing.ByteString in Python 3.14

### DIFF
--- a/jc/parsers/pyedid/edid.py
+++ b/jc/parsers/pyedid/edid.py
@@ -4,7 +4,6 @@ Edid module
 
 import struct
 from collections import namedtuple
-from typing import ByteString
 
 __all__ = ["Edid"]
 
@@ -108,10 +107,10 @@ class Edid:
         ),
     )
 
-    def __init__(self, edid: ByteString):
+    def __init__(self, edid: bytes):
         self._parse_edid(edid)
 
-    def _parse_edid(self, edid: ByteString):
+    def _parse_edid(self, edid: bytes):
         """Convert edid byte string to edid object"""
         if struct.calcsize(self._STRUCT_FORMAT) != 128:
             raise ValueError("Wrong edid size.")

--- a/jc/parsers/pyedid/helpers/edid_helper.py
+++ b/jc/parsers/pyedid/helpers/edid_helper.py
@@ -3,7 +3,7 @@ EDID helper
 """
 
 from subprocess import CalledProcessError, check_output
-from typing import ByteString, List
+from typing import List
 
 __all__ = ["EdidHelper"]
 
@@ -12,14 +12,14 @@ class EdidHelper:
     """Class for working with EDID data"""
 
     @staticmethod
-    def hex2bytes(hex_data: str) -> ByteString:
+    def hex2bytes(hex_data: str) -> bytes:
         """Convert hex EDID string to bytes
 
         Args:
             hex_data (str): hex edid string
 
         Returns:
-            ByteString: edid byte string
+            bytes: edid byte string
         """
         # delete edid 1.3 additional block
         if len(hex_data) > 256:
@@ -32,14 +32,14 @@ class EdidHelper:
         return bytes(numbers)
 
     @classmethod
-    def get_edids(cls) -> List[ByteString]:
+    def get_edids(cls) -> List[bytes]:
         """Get edids from xrandr
 
         Raises:
             `RuntimeError`: if error with retrieving xrandr util data
 
         Returns:
-            List[ByteString]: list with edids
+            List[bytes]: list with edids
         """
         try:
             output = check_output(["xrandr", "--verbose"])


### PR DESCRIPTION
`typing.ByteString` has been removed:

https://docs.python.org/3.14/whatsnew/3.14.html

The modernizing guide suggests `collections.abc.ByteString` which has also been removed; the recommendation is to use either:

- just `bytes`
- `collections.abc.Buffer`
- a union of `bytes`, `bytesarray`, etc.

https://typing.readthedocs.io/en/latest/guides/modernizing.html#modernizing-byte-string

https://docs.python.org/3/library/collections.abc.html#collections.abc.ByteString suggests `bytes | bytesarray` so I'm going with that here.