### PR TITLE
Handle None value in nmcli tables

### DIFF
--- a/jc/parsers/nmcli.py
+++ b/jc/parsers/nmcli.py
@@ -207,6 +207,9 @@ def _normalize_key(keyname: str) -> str:
                   .lower()
 
 def _normalize_value(value: str) -> Optional[str]:
+    if value == None:
+        return None
+
     value = value.strip()
 
     if value == '--':


### PR DESCRIPTION
Fix for #428

There is no need to have another function as `nmcli device wifi list` returns a table that `sparse_table_parse` is already able to parse. The problem is `_normalize_value` is not handling `None` and failing when trying to call `value.strip()`.

Short-circuit `_normalize_value` if `value` is `None`.

I did not added any tests because I couldn't setup the project, I've simply copied `nmcli.py` into `$HOME/.local/share/jc/jcparsers` and tested this change with that.