### PR TITLE
Fix ifconfig hex mask conversion: lstrip('0x') -> [2:]

### DIFF
--- a/jc/parsers/ifconfig.py
+++ b/jc/parsers/ifconfig.py
@@ -264,7 +264,7 @@ def _process(proc_data: List[JSONDictType]) -> List[JSONDictType]:
             try:
                 if entry['ipv4_mask'].startswith('0x'):
                     new_mask = entry['ipv4_mask']
-                    new_mask = new_mask.lstrip('0x')
+                    new_mask = new_mask[2:]
                     new_mask = '.'.join(str(int(i, 16)) for i in [new_mask[i:i + 2] for i in range(0, len(new_mask), 2)])
                     entry['ipv4_mask'] = new_mask
             except (ValueError, TypeError, AttributeError):
@@ -289,7 +289,7 @@ def _process(proc_data: List[JSONDictType]) -> List[JSONDictType]:
                     try:
                         if ip_address['mask'].startswith('0x'):
                             new_mask = ip_address['mask']
-                            new_mask = new_mask.lstrip('0x')
+                            new_mask = new_mask[2:]
                             new_mask = '.'.join(str(int(i, 16)) for i in [new_mask[i:i + 2] for i in range(0, len(new_mask), 2)])
                             ip_address['mask'] = new_mask
                     except (ValueError, TypeError, AttributeError):

--- a/tests/test_ifconfig.py
+++ b/tests/test_ifconfig.py
@@ -148,6 +148,21 @@ class MyTests(unittest.TestCase):
         """
         self.assertEqual(jc.parsers.ifconfig.parse(self.osx_freebsd12_ifconfig_extra_fields4, quiet=True), self.freebsd12_ifconfig_extra_fields4_json)
 
+    def test_ifconfig_hex_mask_all_zeros(self):
+        """
+        Test 'ifconfig' with 0x00000000 netmask (FreeBSD/macOS hex format).
+        Regression test: lstrip('0x') incorrectly strips leading '0' chars
+        from the hex digits, producing wrong mask for all-zero masks.
+        """
+        data = (
+            'lo0: flags=8049<UP,LOOPBACK,RUNNING,MULTICAST> mtu 16384\n'
+            '\toptions=1203<RXCSUM,TXCSUM,TXSTATUS,SW_TIMESTAMP>\n'
+            '\tinet 192.168.1.1 netmask 0x00000000\n'
+        )
+        result = jc.parsers.ifconfig.parse(data, quiet=True)
+        self.assertEqual(result[0]['ipv4_mask'], '0.0.0.0')
+        self.assertEqual(result[0]['ipv4'][0]['mask'], '0.0.0.0')
+
     def test_ifconfig_utun_ipv4(self):
         """
         Test 'ifconfig' with ipv4 utun addresses (macOS)


### PR DESCRIPTION
## Summary

- Fix incorrect hex-to-dotted-quad subnet mask conversion in `ifconfig` parser on macOS/FreeBSD
- `lstrip('0x')` strips any character in the set `{'0','x'}`, not the literal prefix `"0x"` -- this causes masks with leading zero hex digits (e.g. `0x00000000`) to be incorrectly converted
- Replace with `[2:]` slice to correctly remove only the `0x` prefix
- Add regression test for the `0x00000000` mask case

Fixes #685

## Test plan

- [x] New test `test_ifconfig_hex_mask_all_zeros` passes
- [x] All existing 13 ifconfig tests still pass
- [x] Fix applied to both locations in `_process()` (legacy `ipv4_mask` field and `ipv4[]` list)

🤖 Generated with [Claude Code](https://claude.com/claude-code)