### PR TITLE
Fix dir parser: lstrip strips D: drive letter from path

### DIFF
--- a/jc/parsers/dir.py
+++ b/jc/parsers/dir.py
@@ -183,8 +183,8 @@ def parse(data, raw=False, quiet=False):
     if jc.utils.has_data(data):
 
         for line in data.splitlines():
-            if line.startswith(" Directory of"):
-                parent_dir = line.lstrip(" Directory of ")
+            if line.startswith(" Directory of "):
+                parent_dir = line[len(" Directory of "):]
                 continue
             # skip lines that don't start with a date
             if not re.match(r'^\d{2}/\d{2}/\d{4}', line):

--- a/tests/test_dir.py
+++ b/tests/test_dir.py
@@ -95,6 +95,25 @@ class MyTests(unittest.TestCase):
         self.assertEqual(jc.parsers.dir.parse(self.windows_10_dir_S, quiet=True),
                          self.windows_10_dir_S_json)
 
+    def test_dir_drive_letter_d(self):
+        """
+        Test that the D: drive letter is not stripped from the parent path.
+        Regression test: lstrip(" Directory of ") strips any char in the set
+        {' ','D','i','r','e','c','t','o','y','f'}, which incorrectly removes
+        the 'D' from 'D:\\'.
+        """
+        data = (
+            ' Volume in drive D has no label.\r\n'
+            ' Volume Serial Number is 1234-5678\r\n'
+            '\r\n'
+            ' Directory of D:\\Users\\testuser\r\n'
+            '\r\n'
+            '03/24/2021  03:15 PM    <DIR>          .\r\n'
+            '03/24/2021  03:15 PM    <DIR>          ..\r\n'
+        )
+        result = jc.parsers.dir.parse(data, quiet=True)
+        self.assertEqual(result[0]['parent'], 'D:\\Users\\testuser')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary

- Fix `dir` parser incorrectly stripping the `D` drive letter from parent directory paths
- `lstrip(" Directory of ")` treats the argument as a character set, not a prefix -- the uppercase `D` in "Directory" causes `D:\` paths to lose their drive letter
- Replace with `line[len(" Directory of "):]` for correct fixed-length prefix removal
- Add regression test for D: drive paths

Fixes #687

## Test plan

- [x] New test `test_dir_drive_letter_d` passes (verifies `D:\Users\testuser` is preserved)
- [x] All existing 9 dir tests still pass (with America/Los_Angeles timezone as required by CONTRIBUTING.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)