### PR TITLE
fix: add missing VmFlags to proc_pid_smaps parser

### DIFF
--- a/jc/parsers/proc_pid_smaps.py
+++ b/jc/parsers/proc_pid_smaps.py
@@ -231,7 +231,10 @@ def _process(proc_data: List[Dict]) -> List[Dict]:
         'mm':  'mixed map area',
         'hg':  'huge page advise flag',
         'nh':  'no-huge page advise flag',
-        'mg':  'mergable advise flag'
+        'mg':  'mergable advise flag',
+        'um':  'userfaultfd missing pages tracking',
+        'uw':  'userfaultfd write-protect pages tracking',
+        'wf':  'wipe on fork'
     }
 
     for entry in proc_data:
@@ -245,7 +248,7 @@ def _process(proc_data: List[Dict]) -> List[Dict]:
 
         if 'VmFlags' in entry:
             entry['VmFlags'] = entry['VmFlags'].split()
-            entry['VmFlags_pretty'] = [vmflags_map[x] for x in entry['VmFlags']]
+            entry['VmFlags_pretty'] = [vmflags_map.get(x, x) for x in entry['VmFlags']]
 
     return proc_data
 

--- a/tests/fixtures/linux-proc/pid_smaps_wf_flag
+++ b/tests/fixtures/linux-proc/pid_smaps_wf_flag
@@ -1,0 +1,23 @@
+55a9e753c000-55a9e7570000 r--p 00000000 fd:00 798126                     /usr/lib/systemd/systemd
+Size:                208 kB
+KernelPageSize:        4 kB
+MMUPageSize:           4 kB
+Rss:                 208 kB
+Pss:                 104 kB
+Shared_Clean:        208 kB
+Shared_Dirty:          0 kB
+Private_Clean:         0 kB
+Private_Dirty:         0 kB
+Referenced:          208 kB
+Anonymous:             0 kB
+LazyFree:              0 kB
+AnonHugePages:         0 kB
+ShmemPmdMapped:        0 kB
+FilePmdMapped:        0 kB
+Shared_Hugetlb:        0 kB
+Private_Hugetlb:       0 kB
+Swap:                  0 kB
+SwapPss:               0 kB
+Locked:                0 kB
+THPeligible:		0
+VmFlags: rd wr mr mw me nr wf dd sd 

--- a/tests/fixtures/linux-proc/pid_smaps_wf_flag.json
+++ b/tests/fixtures/linux-proc/pid_smaps_wf_flag.json
@@ -1,0 +1,58 @@
+[
+  {
+    "start": "55a9e753c000",
+    "end": "55a9e7570000",
+    "perms": [
+      "read",
+      "private"
+    ],
+    "offset": "00000000",
+    "maj": "fd",
+    "min": "00",
+    "inode": 798126,
+    "pathname": "/usr/lib/systemd/systemd",
+    "Size": 208,
+    "KernelPageSize": 4,
+    "MMUPageSize": 4,
+    "Rss": 208,
+    "Pss": 104,
+    "Shared_Clean": 208,
+    "Shared_Dirty": 0,
+    "Private_Clean": 0,
+    "Private_Dirty": 0,
+    "Referenced": 208,
+    "Anonymous": 0,
+    "LazyFree": 0,
+    "AnonHugePages": 0,
+    "ShmemPmdMapped": 0,
+    "FilePmdMapped": 0,
+    "Shared_Hugetlb": 0,
+    "Private_Hugetlb": 0,
+    "Swap": 0,
+    "SwapPss": 0,
+    "Locked": 0,
+    "THPeligible": 0,
+    "VmFlags": [
+      "rd",
+      "wr",
+      "mr",
+      "mw",
+      "me",
+      "nr",
+      "wf",
+      "dd",
+      "sd"
+    ],
+    "VmFlags_pretty": [
+      "readable",
+      "writeable",
+      "may read",
+      "may write",
+      "may execute",
+      "swap space is not reserved for the area",
+      "wipe on fork",
+      "do not include area into core dump",
+      "soft-dirty flag"
+    ]
+  }
+]

--- a/tests/test_proc_pid_smaps.py
+++ b/tests/test_proc_pid_smaps.py
@@ -16,7 +16,10 @@ class MyTests(unittest.TestCase):
         fixtures = {
             'proc_pid_smaps': (
                 'fixtures/linux-proc/pid_smaps',
-                'fixtures/linux-proc/pid_smaps.json')
+                'fixtures/linux-proc/pid_smaps.json'),
+            'proc_pid_smaps_wf_flag': (
+                'fixtures/linux-proc/pid_smaps_wf_flag',
+                'fixtures/linux-proc/pid_smaps_wf_flag.json')
         }
 
         for file, filepaths in fixtures.items():
@@ -38,6 +41,13 @@ class MyTests(unittest.TestCase):
         """
         self.assertEqual(jc.parsers.proc_pid_smaps.parse(self.f_in['proc_pid_smaps'], quiet=True),
                                                          self.f_json['proc_pid_smaps'])
+
+    def test_proc_pid_smaps_wf_flag(self):
+        """
+        Test '/proc/<pid>/smaps' with wf (wipe-on-fork) VmFlag
+        """
+        self.assertEqual(jc.parsers.proc_pid_smaps.parse(self.f_in['proc_pid_smaps_wf_flag'], quiet=True),
+                                                         self.f_json['proc_pid_smaps_wf_flag'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #681

## Problem

The `proc_pid_smaps` parser crashes with a `KeyError` when `/proc/<pid>/smaps` output contains VmFlags not present in `vmflags_map`. The `wf` (wipe on fork) flag, available since Linux 4.14, triggers this crash:

```
VmFlags: rd wr mr mw me nr wf dd sd dp
                             ^^
KeyError: 'wf'
```

## Fix

1. Add three missing kernel VmFlags to the map: `wf` (wipe on fork), `um` (userfaultfd missing pages tracking), `uw` (userfaultfd write-protect pages tracking).
2. Change the lookup from `vmflags_map[x]` to `vmflags_map.get(x, x)` so any future unrecognized flags fall back to their raw abbreviation instead of crashing.

## Validation

- Reproduced the `KeyError` before the fix
- All existing `test_proc_pid_smaps` tests pass
- Added regression test with a fixture containing the `wf` flag