### PR TITLE
fix: handle filenames with spaces in lsattr parser

### DIFF
--- a/jc/parsers/lsattr.py
+++ b/jc/parsers/lsattr.py
@@ -149,7 +149,7 @@ def parse(
 
         # attributes file
         # --------------e----- /etc/passwd
-        attributes, file = line.split()
+        attributes, file = line.split(None, 1)
         line_output['file'] = file
         for attribute in list(attributes):
             attribute_key = ATTRIBUTES.get(attribute)


### PR DESCRIPTION
Fixes #694

## Problem

`line.split()` with no `maxsplit` splits on every whitespace character. When a filename contains spaces, the unpack `attributes, file = line.split()` raises `ValueError: too many values to unpack`.

**Reproduction:**
```
$ touch "ok ok ok ok ok"
$ lsattr | jc --lsattr
ValueError: too many values to unpack (expected 2, got 6)
```

## Fix

Use `split(None, 1)` to limit the split to the first whitespace boundary. The attributes field (`--------------e-------`) never contains spaces, so the first token is always the attribute flags and everything after the first whitespace is the filename.

```diff
-        attributes, file = line.split()
+        attributes, file = line.split(None, 1)
```

Verified with filenames containing spaces (`./ok ok ok ok ok`) and normal filenames (`./test`).