### PR TITLE
fix: preserve drive letter in dir parser (startswith + slice instead of lstrip)

### DIFF
--- a/jc/parsers/dir.py
+++ b/jc/parsers/dir.py
@@ -183,8 +183,9 @@ def parse(data, raw=False, quiet=False):
     if jc.utils.has_data(data):
 
         for line in data.splitlines():
-            if line.startswith(" Directory of"):
-                parent_dir = line.lstrip(" Directory of ")
+            if line.startswith(" Directory of "):
+                # lstrip() would strip any char in the set, eating the drive letter in 'D:\...'
+                parent_dir = line[len(" Directory of "):]
                 continue
             # skip lines that don't start with a date
             if not re.match(r'^\d{2}/\d{2}/\d{4}', line):


### PR DESCRIPTION
this is a redo of #693 using the approach you suggested — `startswith` + slice instead of `removeprefix` so it stays compatible with legacy python.

the original bug is still there on master: `line.lstrip(' Directory of ')` strips any character in the set {' ','D','i','r','e','c','t','o','y','f'}, so paths starting with D get clobbered:

    >>> ' Directory of D:\\Users\\foo'.lstrip(' Directory of ')
    ':\\Users\\foo'

the C drive fixture didn't catch it because 'C' isn't in the set. verified locally with a D: path — drive letter is preserved with the slice.

thanks for the patient feedback on the last one.