### PR TITLE
fix: use slice [2:] instead of lstrip('0x') for hex subnet masks

### DIFF
--- a/jc/parsers/ifconfig.py
+++ b/jc/parsers/ifconfig.py
@@ -263,8 +263,7 @@ def _process(proc_data: List[JSONDictType]) -> List[JSONDictType]:
         if 'ipv4_mask' in entry:
             try:
                 if entry['ipv4_mask'].startswith('0x'):
-                    new_mask = entry['ipv4_mask']
-                    new_mask = new_mask.lstrip('0x')
+                    new_mask = entry['ipv4_mask'][2:]
                     new_mask = '.'.join(str(int(i, 16)) for i in [new_mask[i:i + 2] for i in range(0, len(new_mask), 2)])
                     entry['ipv4_mask'] = new_mask
             except (ValueError, TypeError, AttributeError):
@@ -288,8 +287,7 @@ def _process(proc_data: List[JSONDictType]) -> List[JSONDictType]:
                 if 'mask' in ip_address:
                     try:
                         if ip_address['mask'].startswith('0x'):
-                            new_mask = ip_address['mask']
-                            new_mask = new_mask.lstrip('0x')
+                            new_mask = ip_address['mask'][2:]
                             new_mask = '.'.join(str(int(i, 16)) for i in [new_mask[i:i + 2] for i in range(0, len(new_mask), 2)])
                             ip_address['mask'] = new_mask
                     except (ValueError, TypeError, AttributeError):


### PR DESCRIPTION
same lstrip-as-prefix-stripper gotcha as the dir parser one (#693 / #702), just in a different parser.

`str.lstrip('0x')` doesn't remove the literal `0x` — it removes any combination of `0` and `x` characters. so a /0 mask (`0x00000000`) ends up as an empty string because every character is in the strip set.

slice `[2:]` removes exactly the first two chars regardless of what comes after.

two call sites had the same pattern — `ipv4_mask` (legacy) and the items in the `ipv4[]` list. both fixed.

fixes #685.