### PR TITLE
fix: replace lstrip() misuse with correct prefix removal in ifconfig and dir parsers

### DIFF
--- a/jc/parsers/dir.py
+++ b/jc/parsers/dir.py
@@ -184,7 +184,7 @@ def parse(data, raw=False, quiet=False):
 
         for line in data.splitlines():
             if line.startswith(" Directory of"):
-                parent_dir = line.lstrip(" Directory of ")
+                parent_dir = line[len(" Directory of "):]  # strip literal prefix (lstrip would strip chars, corrupting drive letters like D:)
                 continue
             # skip lines that don't start with a date
             if not re.match(r'^\d{2}/\d{2}/\d{4}', line):

--- a/jc/parsers/ifconfig.py
+++ b/jc/parsers/ifconfig.py
@@ -264,7 +264,7 @@ def _process(proc_data: List[JSONDictType]) -> List[JSONDictType]:
             try:
                 if entry['ipv4_mask'].startswith('0x'):
                     new_mask = entry['ipv4_mask']
-                    new_mask = new_mask.lstrip('0x')
+                    new_mask = new_mask[2:]  # slice off literal '0x' prefix (lstrip would strip chars, not the string)
                     new_mask = '.'.join(str(int(i, 16)) for i in [new_mask[i:i + 2] for i in range(0, len(new_mask), 2)])
                     entry['ipv4_mask'] = new_mask
             except (ValueError, TypeError, AttributeError):
@@ -289,7 +289,7 @@ def _process(proc_data: List[JSONDictType]) -> List[JSONDictType]:
                     try:
                         if ip_address['mask'].startswith('0x'):
                             new_mask = ip_address['mask']
-                            new_mask = new_mask.lstrip('0x')
+                            new_mask = new_mask[2:]  # slice off literal '0x' prefix (lstrip would strip chars, not the string)
                             new_mask = '.'.join(str(int(i, 16)) for i in [new_mask[i:i + 2] for i in range(0, len(new_mask), 2)])
                             ip_address['mask'] = new_mask
                     except (ValueError, TypeError, AttributeError):

--- a/tests/test_dir.py
+++ b/tests/test_dir.py
@@ -95,6 +95,25 @@ class MyTests(unittest.TestCase):
         self.assertEqual(jc.parsers.dir.parse(self.windows_10_dir_S, quiet=True),
                          self.windows_10_dir_S_json)
 
+    def test_dir_drive_letter_preserved(self):
+        """
+        Test that a drive letter at the start of the Directory path is preserved.
+        lstrip(" Directory of ") incorrectly strips the leading 'D' from 'D:\\...',
+        because lstrip strips individual characters, not a literal prefix string.
+        Regression test for https://github.com/kellyjonbrazil/jc/issues/687.
+        """
+        data = (
+            ' Volume in drive D has no label.\r\n'
+            ' Volume Serial Number is 1234-5678\r\n'
+            '\r\n'
+            ' Directory of D:\\Users\\testuser\r\n'
+            '\r\n'
+            '03/24/2021  03:15 PM    <DIR>          .\r\n'
+            '03/24/2021  03:15 PM    <DIR>          ..\r\n'
+        )
+        result = jc.parsers.dir.parse(data, quiet=True)
+        self.assertEqual(result[0]['parent'], 'D:\\Users\\testuser')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_ifconfig.py
+++ b/tests/test_ifconfig.py
@@ -160,5 +160,18 @@ class MyTests(unittest.TestCase):
         expected = [{"name":"utun2","flags":8051,"state":["UP","POINTOPOINT","RUNNING","MULTICAST"],"mtu":1400,"type":None,"mac_addr":None,"ipv4_addr":"10.85.40.243","ipv4_mask":"255.255.255.255","ipv4_bcast":None,"ipv6_addr":"fdae:f7e0:9f37:64::146","ipv6_mask":128,"ipv6_scope":None,"ipv6_type":None,"metric":None,"rx_packets":None,"rx_errors":None,"rx_dropped":None,"rx_overruns":None,"rx_frame":None,"tx_packets":None,"tx_errors":None,"tx_dropped":None,"tx_overruns":None,"tx_carrier":None,"tx_collisions":None,"rx_bytes":None,"tx_bytes":None,"ipv6_scope_id":None,"nd6_options":201,"nd6_flags":["PERFORMNUD","DAD"],"ipv4":[{"address":"10.85.40.243","mask":"255.255.255.255"}],"ipv6":[{"address":"fe80::3af9:d3ff:fe69:1732","scope_id":"utun2","mask":64,"scope":"0xd"},{"address":"fdae:f7e0:9f37:64::146","scope_id":None,"mask":128,"scope":None}]}]
         self.assertEqual(jc.parsers.ifconfig.parse(self.osx_freebsd12_ifconfig_extra_fields4, quiet=True), self.freebsd12_ifconfig_extra_fields4_json)
 
-if __name__ == '__main__':
-    unittest.main()
+    def test_ifconfig_osx_hex_mask_all_zeros(self):
+        """
+        Test 'ifconfig' with a macOS/FreeBSD hex netmask of 0x00000000.
+        lstrip('0x') incorrectly strips leading hex digits when they are 0,
+        producing an empty string instead of '0.0.0.0'.
+        Regression test for https://github.com/kellyjonbrazil/jc/issues/685.
+        """
+        data = (
+            'lo0: flags=8049<UP,LOOPBACK,RUNNING,MULTICAST> mtu 16384\n'
+            '\toptions=1203<RXCSUM,TXCSUM,TXSTATUS,SW_TIMESTAMP>\n'
+            '\tinet 192.168.1.1 netmask 0x00000000\n'
+        )
+        result = jc.parsers.ifconfig.parse(data, quiet=True)
+        self.assertEqual(result[0]['ipv4_mask'], '0.0.0.0')
+


### PR DESCRIPTION
Fixes #685, fixes #687

## Problem

`str.lstrip(chars)` strips **any combination** of the given characters from the left — not the literal string. This caused two silent bugs in two parsers:

### 1. `jc/parsers/ifconfig.py` (#685)

```python
new_mask.lstrip('0x')
```

On a mask like `'0x00000000'`, this strips all leading `'0'`, `'x'` chars — since `'0'` appears in both the prefix and the mask digits — leaving an empty string instead of `'0.0.0.0'`.

### 2. `jc/parsers/dir.py` (#687)

```python
line.lstrip(' Directory of ')
```

The character set includes `'D'`, so a path like `'D:\\Users\\testuser'` loses its drive letter, becoming `':\\Users\\testuser'`.

## Fix

Replace both `lstrip()` calls with exact prefix removal:

```python
# ifconfig.py — slice off exactly '0x'
new_mask[2:]

# dir.py — use len() to strip the exact prefix string
line[len(' Directory of '):]
```

## Tests

Added regression tests in `tests/test_ifconfig.py` and `tests/test_dir.py` covering the broken inputs.
