### PR TITLE
fix: strip per-rule (log)/(log-all) markers in ufw parser (#696)

### DIFF
--- a/jc/parsers/ufw.py
+++ b/jc/parsers/ufw.py
@@ -280,6 +280,10 @@ def _parse_to_from(linedata, direction, rule_obj=None):
     elif not rule_obj.get('network_protocol'):
         rule_obj['network_protocol'] = 'ipv4'
 
+    # pull (log) and (log-all) - these are per-rule logging markers
+    RE_LOG = re.compile(r'\(log(?:-all)?\)')
+    linedata = re.sub(RE_LOG, '', linedata)
+
     # pull 'Anywhere' if exists. Assign to 0.0.0.0/0 or ::/0 depending on if (v6) is found
     if 'Anywhere' in linedata:
         if rule_obj.get('network_protocol') == 'ipv6':

--- a/tests/fixtures/generic/ufw-log.json
+++ b/tests/fixtures/generic/ufw-log.json
@@ -1,0 +1,86 @@
+{
+  "status": "active",
+  "logging": "on",
+  "logging_level": "low",
+  "default": "deny (incoming), allow (outgoing), deny (routed)",
+  "rules": [
+    {
+      "action": "ALLOW",
+      "action_direction": "IN",
+      "index": null,
+      "network_protocol": "ipv4",
+      "to_interface": "any",
+      "to_transport": "tcp",
+      "to_service": null,
+      "to_ports": [
+        80
+      ],
+      "to_ip": "0.0.0.0",
+      "to_ip_prefix": 0,
+      "comment": "Allow HTTP from build server",
+      "from_interface": "any",
+      "from_transport": "any",
+      "from_ip": "1.2.3.4",
+      "from_ip_prefix": 32,
+      "from_port_ranges": [
+        {
+          "start": 0,
+          "end": 65535
+        }
+      ],
+      "from_service": null
+    },
+    {
+      "action": "ALLOW",
+      "action_direction": "IN",
+      "index": null,
+      "network_protocol": "ipv4",
+      "to_interface": "any",
+      "to_transport": "tcp",
+      "to_service": null,
+      "to_ports": [
+        443
+      ],
+      "to_ip": "0.0.0.0",
+      "to_ip_prefix": 0,
+      "comment": null,
+      "from_interface": "any",
+      "from_transport": "any",
+      "from_ip": "10.0.0.0",
+      "from_ip_prefix": 8,
+      "from_port_ranges": [
+        {
+          "start": 0,
+          "end": 65535
+        }
+      ],
+      "from_service": null
+    },
+    {
+      "action": "ALLOW",
+      "action_direction": "IN",
+      "index": null,
+      "network_protocol": "ipv4",
+      "to_interface": "any",
+      "to_transport": "tcp",
+      "to_service": null,
+      "to_ports": [
+        22
+      ],
+      "to_ip": "0.0.0.0",
+      "to_ip_prefix": 0,
+      "comment": null,
+      "from_ip": "0.0.0.0",
+      "from_ip_prefix": 0,
+      "from_interface": "any",
+      "from_transport": "any",
+      "from_port_ranges": [
+        {
+          "start": 0,
+          "end": 65535
+        }
+      ],
+      "from_service": null
+    }
+  ]
+}

--- a/tests/fixtures/generic/ufw-log.out
+++ b/tests/fixtures/generic/ufw-log.out
@@ -1,0 +1,9 @@
+Status: active
+Logging: on (low)
+Default: deny (incoming), allow (outgoing), deny (routed)
+
+To                         Action      From
+--                         ------      ----
+80/tcp                     ALLOW IN    1.2.3.4        (log)  # Allow HTTP from build server
+443/tcp                    ALLOW IN    10.0.0.0/8     (log-all)
+22/tcp                     ALLOW IN    Anywhere

--- a/tests/test_ufw.py
+++ b/tests/test_ufw.py
@@ -27,6 +27,9 @@ class MyTests(unittest.TestCase):
     with open(os.path.join(THIS_DIR, os.pardir, 'tests/fixtures/generic/ufw-inactive.out'), 'r', encoding='utf-8') as f:
         generic_ufw_inactive = f.read()
 
+    with open(os.path.join(THIS_DIR, os.pardir, 'tests/fixtures/generic/ufw-log.out'), 'r', encoding='utf-8') as f:
+        generic_ufw_log = f.read()
+
     # output
     with open(os.path.join(THIS_DIR, os.pardir, 'tests/fixtures/ubuntu-18.04/ufw-verbose.json'), 'r', encoding='utf-8') as f:
         ubuntu_18_04_ufw_verbose_json = json.loads(f.read())
@@ -45,6 +48,9 @@ class MyTests(unittest.TestCase):
 
     with open(os.path.join(THIS_DIR, os.pardir, 'tests/fixtures/generic/ufw-inactive.json'), 'r', encoding='utf-8') as f:
         generic_ufw_inactive_json = json.loads(f.read())
+
+    with open(os.path.join(THIS_DIR, os.pardir, 'tests/fixtures/generic/ufw-log.json'), 'r', encoding='utf-8') as f:
+        generic_ufw_log_json = json.loads(f.read())
 
 
     def test_ufw_nodata(self):
@@ -88,6 +94,12 @@ class MyTests(unittest.TestCase):
         Test 'ufw status' when firewall is inactive
         """
         self.assertEqual(jc.parsers.ufw.parse(self.generic_ufw_inactive, quiet=True), self.generic_ufw_inactive_json)
+
+    def test_ufw_generic_log(self):
+        """
+        Test 'ufw status verbose' with per-rule (log) and (log-all) markers
+        """
+        self.assertEqual(jc.parsers.ufw.parse(self.generic_ufw_log, quiet=True), self.generic_ufw_log_json)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description

Fixes #696

The ufw parser's `_parse_to_from()` function did not strip `(log)` and `(log-all)` per-rule logging markers from the from/to line data. This caused `(log)` to be incorrectly assigned as `from_service`.

## Changes

- **`jc/parsers/ufw.py`**: Added regex stripping of `(log)` and `(log-all)` patterns in `_parse_to_from()`, right after the `(v6)` pattern is handled
- **`tests/test_ufw.py`**: Added test case for per-rule log markers
- **`tests/fixtures/generic/ufw-log.out`**: Test fixture with `(log)` and `(log-all)` rules
- **`tests/fixtures/generic/ufw-log.json`**: Expected output for the test fixture

## Testing

All 8 ufw tests pass (7 existing + 1 new).