### PR TITLE
fix: New parser: php-fpm8.2 -tt

### DIFF
--- a/jc/lib.py
+++ b/jc/lib.py
@@ -119,6 +119,7 @@ parsers: List[str] = [
     'path-list',
     'pci-ids',
     'pgpass',
+    'php-fpm',
     'pidstat',
     'pidstat-s',
     'ping',

--- a/jc/parsers/php_fpm.py
+++ b/jc/parsers/php_fpm.py
@@ -1,0 +1,88 @@
+"""
+`php-fpm -tt` command parser
+
+Parses the configuration dump written to standard error by versioned and
+unversioned PHP-FPM executables when invoked with the `-tt` option.
+
+The output schema is:
+
+    {
+      "POOL_NAME": {
+        "DIRECTIVE_NAME": "value"
+      }
+    }
+
+All directive values are retained as strings. The same representation is used
+when `raw=True`.
+"""
+import re
+from typing import Dict, Optional, Union
+
+
+class info:
+    version = '1.0'
+    description = '`php-fpm -tt` command parser'
+    author = 'JC Contributors'
+    author_email = ''
+    compatible = ['linux']
+    tags = ['command']
+
+
+_NOTICE_RE = re.compile(
+    r'^\[[^\]]+\]\s+NOTICE:\s?(?P<payload>.*)$'
+)
+_SECTION_RE = re.compile(r'^\[(?P<section>[^\]]+)\]$')
+_SUCCESS_RE = re.compile(r'^configuration file .+ test is successful$')
+
+
+def parse(
+    data: Union[str, bytes],
+    raw: bool = False,
+    quiet: bool = False
+) -> Dict[str, Dict[str, str]]:
+    """
+    Convert `php-fpm -tt` output to a dictionary.
+
+    Parameters:
+
+        data:   `php-fpm -tt` output as a string or bytes
+        raw:    ignored because values are always retained as strings
+        quiet:  accepted for parser API compatibility
+
+    Returns:
+
+        Dictionary keyed by PHP-FPM configuration section or pool name.
+    """
+    del raw, quiet
+
+    if isinstance(data, bytes):
+        data = data.decode('utf-8')
+
+    output: Dict[str, Dict[str, str]] = {}
+    current_section: Optional[str] = None
+
+    for line in data.splitlines():
+        notice = _NOTICE_RE.match(line)
+        if not notice:
+            continue
+
+        payload = notice.group('payload').strip()
+        if not payload or _SUCCESS_RE.match(payload):
+            continue
+
+        section = _SECTION_RE.match(payload)
+        if section:
+            current_section = section.group('section').strip()
+            output.setdefault(current_section, {})
+            continue
+
+        if current_section is None or '=' not in payload:
+            continue
+
+        key, value = payload.split('=', 1)
+        key = key.strip()
+        value = value.strip()
+        if key:
+            output[current_section][key] = value
+
+    return output

--- a/tests/test_php_fpm.py
+++ b/tests/test_php_fpm.py
@@ -1,0 +1,62 @@
+import unittest
+
+from jc.parsers import php_fpm
+
+
+PHP_FPM_OUTPUT = """[25-Feb-2024 20:25:25] NOTICE: [global]
+[25-Feb-2024 20:25:25] NOTICE:  pid = /run/php/php8.2-fpm.pid
+[25-Feb-2024 20:25:25] NOTICE:  log_level = unknown value
+[25-Feb-2024 20:25:25] NOTICE:
+[25-Feb-2024 20:29:38] NOTICE: [www]
+[25-Feb-2024 20:29:38] NOTICE:  user = www-data
+[25-Feb-2024 20:29:38] NOTICE:  security.limit_extensions = .php .phar
+[25-Feb-2024 20:29:38] NOTICE: configuration file /etc/php/8.2/fpm/php-fpm.conf test is successful
+"""
+
+
+EXPECTED = {
+    'global': {
+        'pid': '/run/php/php8.2-fpm.pid',
+        'log_level': 'unknown value',
+    },
+    'www': {
+        'user': 'www-data',
+        'security.limit_extensions': '.php .phar',
+    },
+}
+
+
+class PhpFpmTests(unittest.TestCase):
+    def test_parses_php_fpm_82_output(self):
+        self.assertEqual(php_fpm.parse(PHP_FPM_OUTPUT), EXPECTED)
+
+    def test_accepts_bytes_and_raw_mode(self):
+        self.assertEqual(
+            EXPECTED,
+            php_fpm.parse(PHP_FPM_OUTPUT.encode('utf-8'), raw=True),
+        )
+
+    def test_supports_arbitrary_pool_names_and_equals_in_values(self):
+        sample = (
+            '[01-Mar-2024 10:00:00] NOTICE: [api]\n'
+            '[01-Mar-2024 10:00:00] NOTICE:  listen = 127.0.0.1:9000\n'
+            '[01-Mar-2024 10:00:00] NOTICE:  env[QUERY] = one=two\n'
+            '[01-Mar-2024 10:00:00] NOTICE:  process.dumpable = no\n'
+        )
+        self.assertEqual(
+            php_fpm.parse(sample),
+            {
+                'api': {
+                    'listen': '127.0.0.1:9000',
+                    'env[QUERY]': 'one=two',
+                    'process.dumpable': 'no',
+                }
+            },
+        )
+
+    def test_ignores_unrelated_diagnostics(self):
+        sample = (
+            'unrelated stderr output\n'
+            '[01-Mar-2024 10:00:00] ERROR: unable to load configuration\n'
+            '[01-Mar-2024 10:00:00] NOTICE: configuration file /tmp/fpm.conf test is successful\n'
+        )


### PR DESCRIPTION
Closes #546

I used an AI coding assistant to help draft this patch (new php-fpm parser + tests), then reviewed the diff and ran the test suite locally before opening this PR. Happy to make adjustments if the approach doesn't fit the project's conventions.

Tests: `python -m unittest discover -s tests -p 'test_php_fpm.py'`