### PR TITLE
test: find setup.py when tests are copied into a build tree

### DIFF
--- a/tests/test_jc.py
+++ b/tests/test_jc.py
@@ -43,12 +43,35 @@ class MyTests(unittest.TestCase):
     def test_jc_slurpable_parser_mod_list_is_list(self):
         self.assertIsInstance(jc.slurpable_parser_mod_list(), list)
 
+    def _project_root(self):
+        """Return the directory that contains setup.py.
+
+        Walk up from the test file so the check still works when tests are
+        copied into a build tree (Debian pybuild uses
+        `.pybuild/.../build/tests`, so `tests/../setup.py` is missing).
+        """
+        path = THIS_DIR
+        for _ in range(8):
+            if os.path.isfile(os.path.join(path, 'setup.py')):
+                return path
+            parent = os.path.dirname(path)
+            if parent == path:
+                break
+            path = parent
+        return None
+
     def test_version_info(self):
         """Test that the lib and pkg version strings match."""
-        with open(os.path.join(THIS_DIR, os.pardir, 'jc/lib.py'), 'r', encoding='utf-8') as f:
+        project_root = self._project_root()
+        self.assertIsNotNone(
+            project_root,
+            'setup.py not found above the test directory'
+        )
+
+        with open(os.path.join(project_root, 'jc/lib.py'), 'r', encoding='utf-8') as f:
             lib_file = f.read()
 
-        with open(os.path.join(THIS_DIR, os.pardir, 'setup.py'), 'r', encoding='utf-8') as f:
+        with open(os.path.join(project_root, 'setup.py'), 'r', encoding='utf-8') as f:
             pkg_file = f.read()
 
         lib_pattern = re.compile(r'''__version__ = \'(?P<ver>\d+\.\d+\.\d+)\'''')


### PR DESCRIPTION
Fixes #718.

## What changed

`test_version_info` opened `tests/../setup.py`. That works in a git checkout, but Debian pybuild copies tests into `.pybuild/.../build/tests`, so the relative `setup.py` path is missing even though the file is still in the unpacked source root.

The test now walks up from the test file until it finds `setup.py`, then reads `jc/lib.py` and `setup.py` from that directory. The version-string assertion is unchanged.

## Tests

Reproduced the Debian layout locally: unpatched test raises `FileNotFoundError` for `.../build/tests/../setup.py`; patched test passes.

- `python3 -m unittest tests.test_jc` — 9 passed
- `TZ=America/Los_Angeles python -m unittest discover tests` with `requirements.txt` — 1573 tests, 11 skipped, 0 failed (same command/timezone as CI)

## AI assistance disclosure

Cursor Grok assisted with locating the pybuild path mismatch, drafting the walk-up helper, and writing this PR body. I reviewed the diff and ran the tests above.