### PR TITLE
fix(hosts): ignore whitespace-only lines

### DIFF
--- a/jc/parsers/hosts.py
+++ b/jc/parsers/hosts.py
@@ -74,7 +74,7 @@ import jc.utils
 
 class info():
     """Provides parser metadata (version, author, etc.)"""
-    version = '1.4'
+    version = '1.5'
     description = '`/etc/hosts` file parser'
     author = 'Kelly Brazil'
     author_email = 'kellyjonbrazil@gmail.com'
@@ -122,7 +122,7 @@ def parse(data, raw=False, quiet=False):
     raw_output = []
 
     # Clear any blank lines
-    cleandata = list(filter(None, data.splitlines()))
+    cleandata = [line for line in data.splitlines() if line.strip()]
 
     if jc.utils.has_data(data):
 

--- a/tests/test_hosts.py
+++ b/tests/test_hosts.py
@@ -29,6 +29,14 @@ class MyTests(unittest.TestCase):
         """
         self.assertEqual(jc.parsers.hosts.parse('', quiet=True), [])
 
+    def test_hosts_whitespace_only_line(self):
+        """
+        Test 'cat /etc/hosts' with a whitespace-only line
+        """
+        data = ' \t \n127.0.0.1 localhost\n'
+        expected = [{'ip': '127.0.0.1', 'hostname': ['localhost']}]
+        self.assertEqual(jc.parsers.hosts.parse(data, quiet=True), expected)
+
     def test_hosts_centos_7_7(self):
         """
         Test 'cat /etc/hosts' on Centos 7.7


### PR DESCRIPTION
`hosts.parse()` filters empty strings but keeps lines containing only spaces or tabs. Splitting one of those lines produces no fields, so the parser raises `IndexError` instead of continuing to the next hosts entry.

This treats whitespace-only lines as blank while preserving the original text of nonblank lines. The regression test includes spaces and a tab before a valid hosts entry.

Validation:

- `python -m unittest tests.test_hosts` — 4 passed
- `TZ=America/Los_Angeles python -m unittest discover tests` — 1577 passed, 7 skipped

Fixes #742.